### PR TITLE
named conditionals 

### DIFF
--- a/3.5/cgi-bin/mycodo.py
+++ b/3.5/cgi-bin/mycodo.py
@@ -3811,9 +3811,19 @@ def Relays_Start():
                     GPIO.output(relay_pin[i], 0)
 
 
-# Read the state of a relay
 def read_relay(relay):
-    if (relay_trigger[relay - 1] == 0 and GPIO.input(relay_pin[relay - 1]) == 0) or (relay_trigger[relay - 1] == 1 and GPIO.input(relay_pin[relay - 1]) == 1):
+    """
+    Read the state of a relay
+
+    :param relay:
+    :type relay:
+    :return: State of the relay as a string.  Either 'on' or 'off'
+    :rtype: str
+    """
+    rename_this_condition1 = relay_trigger[relay - 1] == 0 and GPIO.input(relay_pin[relay - 1]) == 0
+    rename_this_condition2 = relay_trigger[relay - 1] == 1 and GPIO.input(relay_pin[relay - 1]) == 1
+
+    if rename_this_condition1 or rename_this_condition2:
         return "on"
     else:
         return "off"


### PR DESCRIPTION
This code is a test to see if you would be open to it.  I see a lot of conditionals that are difficult to understand because I am not familiar with the pin settings.  This particular function ```read_relay``` has two conditions that if either are true the relay is considered 'on'.   Rather than have the magic numbers in the conditional I am thinking that you could name these.   Something like 'relay_engaged_down' or 'relay_engaged_up'...  I am taking a wild guess here, that probably isn't what is happening.

If we can break some of the longer lines up into local variables I believe the code could be much easier to read.   