### PR TITLE
Add tag for webapp osx

### DIFF
--- a/mycodo/mycodo_flask/templates/layout.html
+++ b/mycodo/mycodo_flask/templates/layout.html
@@ -8,7 +8,41 @@
   <meta name="description" content="">
   <meta name="author" content="">
   <link rel="icon" type="image/png" href="/static/img/favicon.png">
+    
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-title" content="Mycodo {{mycodo_version}}">
+  <meta name="application-name" content="Mycodo {{mycodo_version}}">
+  <meta name="theme-color" content="#ffffff">
 
+  <link rel="apple-touch-icon" href="/static/img/apple-touch-icon.png" />   <!-- include this image in static/img/ folder -->
+    
+  <!-- the next script is for standalone webapp osx -->
+  <script type="text/javascript">
+    (function(document,navigator,standalone) {
+      // prevents links from apps from oppening in mobile safari
+      // this javascript must be the first script in your <head>
+      if ((standalone in navigator) && navigator[standalone]) {
+        var curnode, location=document.location, stop=/^(a|html)$/i;
+        document.addEventListener('click', function(e) {
+          curnode=e.target;
+          while (!(stop).test(curnode.nodeName)) {
+            curnode=curnode.parentNode;
+          }
+          // Condidions to do this only on links to your own app
+          // if you want all links, use if('href' in curnode) instead.
+          if(
+            'href' in curnode && // is a link
+            (chref=curnode.href).replace(location.href,'').indexOf('#') && // is not an anchor
+            (	!(/^[a-z\+\.\-]+:/i).test(chref) ||                       // either does not have a proper scheme (relative links)
+              chref.indexOf(location.protocol+'//'+location.host)===0 ) // or is in the same protocol and domain
+          ) {
+            e.preventDefault();
+            location.href = curnode.href;
+          }
+        },false);
+      }
+    })(document,window.navigator,'standalone');
+  </script>
   <title>{{host}}{% block title %}{% endblock %} - Mycodo {{mycodo_version}}</title>
 
   <link rel="stylesheet" href="/static/css/font-awesome.min.css">


### PR DESCRIPTION
this is the file that you need upload in /static/img/. this file is the icon that setting when adding to home the page live:
![apple-touch-icon](https://user-images.githubusercontent.com/2304258/32712819-453bfa9e-c825-11e7-9571-0ca95f861b5f.png)

the results is this:
![img_4527](https://user-images.githubusercontent.com/2304258/32713073-5965b86a-c826-11e7-805d-6713c7cfc6ce.jpg)
![img_4528](https://user-images.githubusercontent.com/2304258/32713074-59953d2e-c826-11e7-9338-dac1f1d8d601.PNG)
![img_4529](https://user-images.githubusercontent.com/2304258/32713076-59b9f182-c826-11e7-82e4-aa41d2da8a10.PNG)

I've been led by https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html

and

https://gist.github.com/irae/1042167