### PR TITLE
Add method to disable ABC feature of B version sensor

### DIFF
--- a/mycodo/inputs/mh_z19.py
+++ b/mycodo/inputs/mh_z19.py
@@ -124,3 +124,12 @@ class InputModule(AbstractInput):
         finally:
             self.acquiring_measurement = False
         return 1
+    
+    def abcoff(self):
+        """
+        Turns off Automatic Baseline Correction feature of "B" type sensor.
+        Should be run once at the beginning of every activation.
+        The pattern to toggle on is "ff 01 79 a0 00 00 00 00 e6"
+        """
+        self.ser.write(bytearray([0xff, 0x01, 0x79, 0x00, 0x00, 0x00, 0x00, 0x00, 0x86]))
+        return


### PR DESCRIPTION
This is just a suggestion of a minimum to do - you will probably want to re-write it into the init or where it makes sense to catch the point of activating.  My assumption is that you never need to enable (probably wrong).  I think this may be programmed into the firmware and re-enabled with any reset, self initiated or external (power cycle, etc.) I'll bet lots of folks think they have a defective sensor after some time operating, assuming they ever question the data.