### PR TITLE
Fix Travis build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y libboost-python-dev gawk git libav-tools libffi-dev libi2c-dev nginx python3 python3-dev python3-numpy sqlite3 swig
   - git clone --recursive https://github.com/WiringPi/WiringPi-Python.git && cd WiringPi-Python && git submodule update --init && cd WiringPi && ./build && cd ../..
-  - wget abyz.me.uk/rpi/pigpio/pigpio.tar && tar xf pigpio.tar && cd ./PIGPIO && make -j4 && sudo make install && cd ..
+  - wget https://github.com/joan2937/pigpio/archive/master.zip && unzip master.zip && cd ./pigpio-master && make -j4 && sudo make install && cd ..
   - pip install --upgrade pip webtest
   - wget https://dl.influxdata.com/influxdb/releases/influxdb_1.7.8_amd64.deb && sudo dpkg -i influxdb_1.7.8_amd64.deb
   - sudo service influxdb start && sleep 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install -y libboost-python-dev gawk git libav-tools libffi-dev libi2c-dev nginx python3 python3-dev python3-numpy sqlite3 swig
   - git clone --recursive https://github.com/WiringPi/WiringPi-Python.git && cd WiringPi-Python && git submodule update --init && cd WiringPi && ./build && cd ../..
-  - wget https://github.com/joan2937/pigpio/archive/master.zip && unzip master.zip && cd ./pigpio-master && make -j4 && sudo make install && cd ..
+  - wget https://github.com/joan2937/pigpio/archive/v75.zip && unzip master.zip && cd ./pigpio-master && make -j4 && sudo make install && cd ..
   - pip install --upgrade pip webtest
   - wget https://dl.influxdata.com/influxdb/releases/influxdb_1.7.8_amd64.deb && sudo dpkg -i influxdb_1.7.8_amd64.deb
   - sudo service influxdb start && sleep 2


### PR DESCRIPTION
Fix Travis CI build errors #3378-Present. PiGPIO installation methods regarding wget from abyz.com/... are no longer supported, change wget source and unzip procedure to reflect new install methods.