### PR TITLE
Update README.rst - Correct `proportional-integral-derivative` in PID section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ The latest API documentation can be found here: `API Information <https://kiznic
 About PID Control
 -----------------
 
-A `proportional-derivative-integral (PID) controller <https://en.wikipedia.org/wiki/PID_controller>`__ is a control loop feedback mechanism used throughout industry for controlling systems. It efficiently brings a measurable condition, such as temperature, to a desired state (setpoint). A well-tuned PID controller can raise to a setpoint quickly, have minimal overshoot, and maintain the setpoint with little oscillation.
+A `proportional–integral–derivative (PID) controller <https://en.wikipedia.org/wiki/PID_controller>`__ is a control loop feedback mechanism used throughout industry for controlling systems. It efficiently brings a measurable condition, such as temperature, to a desired state (setpoint). A well-tuned PID controller can raise to a setpoint quickly, have minimal overshoot, and maintain the setpoint with little oscillation.
 
 .. figure:: docs/images/PID-Animation.gif
    :alt: PID Animation


### PR DESCRIPTION
Changed "proportional-derivative-integral" to "proportional-integral-derivative" (PID).