### PR TITLE
tweak: reworked widget title bar on dashboard widgets

### DIFF
--- a/mycodo/mycodo_flask/static/css/custom.css
+++ b/mycodo/mycodo_flask/static/css/custom.css
@@ -105,6 +105,7 @@
 .widget-settings a {
   opacity: 0.4;
   outline: none;
+  border: 0;
 }
 
 .widget-settings a:hover,

--- a/mycodo/mycodo_flask/static/css/custom.css
+++ b/mycodo/mycodo_flask/static/css/custom.css
@@ -73,3 +73,45 @@
 .table {
   margin-bottom: 0;
 }
+
+.widget-heading {
+  flex: 0 1 auto;
+  padding-top: 0.5em;
+}
+
+.widget-drag-handle {
+  position: absolute;
+  left: 0.75em;
+  top: 0.75em;
+  opacity: 0.4;
+}
+
+.widget-title {
+  width: 100%;
+  margin: 0 1.5em;
+  text-align: center;
+}
+
+.widget-title span {
+  padding: 0 0.5em;
+}
+
+.widget-settings {
+  position: absolute;
+  right: 0.75em;
+  top: 0.75em;
+}
+
+.widget-settings a {
+  opacity: 0.4;
+  outline: none;
+}
+
+.widget-settings a:hover,
+.widget-settings a:active {
+  opacity: 1.0;
+}
+
+.widget-settings .btn {
+  padding: 0;
+}

--- a/mycodo/mycodo_flask/templates/pages/dashboard.html
+++ b/mycodo/mycodo_flask/templates/pages/dashboard.html
@@ -72,23 +72,25 @@
 
       {% if each_widget.graph_type in dict_widgets %}
 
-        <div class="d-flex justify-content-between panel-heading" style="flex: 0 1 auto;">
-          <div class="my-auto" style="padding-left: 0.4em">
+        <div class="d-flex justify-content-between panel-heading widget-heading">
+          <div class="my-auto widget-drag-handle">
             {% if each_widget.enable_drag_handle -%}
-            <i style="font-size: 1.5em" class="fas fa-grip-horizontal" title="Drag"></i>
+              <i style="font-size: 1.5em" class="fas fa-grip-horizontal" title="Drag"></i>
             {%- endif %}
           </div>
-          <div class="my-auto">
 
-        {% for widget_type, file_title_bar in list_html_files_title_bar.items() if widget_type == each_widget.graph_type %}
-            <!-- Widget {{widget_type}} title_bar template begin -->
-            {% include 'user_templates/{}'.format(file_title_bar) %}
-            <!-- Widget {{widget_type}} title_bar template end -->
-        {% endfor %}
+          <div class="my-auto widget-title">
+            {% for widget_type, file_title_bar in list_html_files_title_bar.items() if widget_type == each_widget.graph_type %}
+              <!-- Widget {{widget_type}} title_bar template begin -->
+              {% include 'user_templates/{}'.format(file_title_bar) %}
+              <!-- Widget {{widget_type}} title_bar template end -->
+            {% endfor %}
+          </div>
 
-            <button type="button" class="btn btn-link" style="padding: 0" data-toggle="modal" data-target="#modal_config_{{chart_number}}">
+          <div class="my-auto widget-settings">
+            <a class="btn" data-toggle="modal" data-target="#modal_config_{{chart_number}}">
               <i style="font-size: 1.5em" class="fas fa-cog"></i>
-            </button>
+            </a>
           </div>
         </div>
 


### PR DESCRIPTION
This proposed change removes much of the inline CSS styling on dashboard widgets and centers widget titles within their panels.

I've also knocked down the opacity on the settings cog icon unless the mouse is hovering over the icon or the link is active.

This change has been tested in Chrome, Firefox, Safari, and Opera without displaying any issues at various browser sizes. I also tested all themes to ensure that the change did not break any styling.

Dragging works along with the settings cog link.

I will note that there's still some inline CSS styling being added programmatically via this line:

```python
{% include 'user_templates/{}'.format(file_title_bar) %}
```

For instance, `padding-right` is being added to titles in this function. That inline style is no longer needed. I wasn't able to find the `format` method in the Mycodo codebase, but I did not search too extensively.

## Normal

![Mycodo Dashboard - Normal](https://user-images.githubusercontent.com/50302519/98959688-256f2700-24c9-11eb-9be8-8041528e60ed.png)

## Hover over Cog Icon (Settings)

![Mycodo Dashboard - Hover](https://user-images.githubusercontent.com/50302519/98959759-36b83380-24c9-11eb-85db-d5c499399788.png)

## Smaller Screens

![Mycodo Dashboard - Small Screens](https://user-images.githubusercontent.com/50302519/98959796-4172c880-24c9-11eb-8ef3-203f3e1fa7fc.png)

## Dark Theme

![Mycodo Dashboard - Dark Theme](https://user-images.githubusercontent.com/50302519/98964902-fc519500-24ce-11eb-87de-e7da063e989b.png)

## Android (Chrome)

![Mycodo Dashboard - Android (Chrome)](https://user-images.githubusercontent.com/50302519/98966661-24da8e80-24d1-11eb-896b-9442a5ed88e6.jpg)
