### PR TITLE
tweak: center indicator graphic within indicator widget

### DIFF
--- a/mycodo/mycodo_flask/static/css/custom.css
+++ b/mycodo/mycodo_flask/static/css/custom.css
@@ -157,3 +157,17 @@
     text-align: left;
   }
 }
+
+.widget-indicator-body {
+  text-align: center;
+}
+
+.widget-indicator-body img {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin-right: -50%;
+  transform: translate(-50%,-50%);
+  max-width: 60%;
+  max-height: 60%;
+}

--- a/mycodo/widgets/widget_indicator.py
+++ b/mycodo/widgets/widget_indicator.py
@@ -105,9 +105,9 @@ WIDGET_INFORMATION = {
 
     'widget_dashboard_head': """<!-- No head content -->""",
 
-    'widget_dashboard_title_bar': """<span style="padding-right: 0.5em; font-size: {{each_widget.font_em_name}}em">{{each_widget.name}}</span>""",
+    'widget_dashboard_title_bar': """<span style="font-size: {{each_widget.font_em_name}}em">{{each_widget.name}}</span>""",
 
-    'widget_dashboard_body': """<div style="text-align: center"><img style="max-width: 60%; max-height: 60%" id="value-{{chart_number}}" src="" alt=""></div>""",
+    'widget_dashboard_body': """<div class="widget-indicator-body"><img id="value-{{chart_number}}" src="" alt=""></div>""",
 
     'widget_dashboard_js': """<!-- No JS content -->""",
 


### PR DESCRIPTION
Small change to horizontally and vertically center the indicator graphic within the indicator widget.

![Screen Shot 2020-11-17 at 10 00 21 AM](https://user-images.githubusercontent.com/50302519/99414258-42866a00-28bc-11eb-97f0-81887969371e.png)
