### PR TITLE
Change navbar brand link to go to preferred landing page

### DIFF
--- a/mycodo/mycodo_flask/templates/layout.html
+++ b/mycodo/mycodo_flask/templates/layout.html
@@ -176,7 +176,7 @@
 
     <nav id="nav-respond" class="navbar navbar-expand-md{% if current_user.theme in dark_themes %} navbar-dark bg-dark{% else %} navbar-light bg-light{% endif %}">
 
-      <a class="navbar-brand" id="daemon-status" data-toggle="tooltip" data-placement="bottom" href="{{url_for('routes_page.page_info')}}" style="text-align: center; padding: 0 15px; font-size: 0.8em; font-weight: bold;{%- if daemon_status == "alive" -%} /*noinspection CssOverwrittenProperties*/color: #4E9258{%- else -%} /*noinspection CssOverwrittenProperties*/color: #F70D1A{%- endif -%}" title="{%- if daemon_status == "alive" -%}{{_('Daemon is Running')}}{%- else -%}{{_('Daemon is Not Running')}}{%- endif -%}">{{host}} - {{mycodo_version}}<br><span id="time-update"></span></a>
+      <a class="navbar-brand" id="daemon-status" data-toggle="tooltip" data-placement="bottom" href="{{url_for('routes_general.home')}}" style="text-align: center; padding: 0 15px; font-size: 0.8em; font-weight: bold;{%- if daemon_status == "alive" -%} /*noinspection CssOverwrittenProperties*/color: #4E9258{%- else -%} /*noinspection CssOverwrittenProperties*/color: #F70D1A{%- endif -%}" title="{%- if daemon_status == "alive" -%}{{_('Daemon is Running')}}{%- else -%}{{_('Daemon is Not Running')}}{%- endif -%}">{{host}} - {{mycodo_version}}<br><span id="time-update"></span></a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>


### PR DESCRIPTION
Currently, the navbar's brand link ("Hostname - Version") takes users to the System Information (/info) page. I'd argue that it makes more sense for this link to go to the user's preferred landing page (`routes_general.home`).

Users can still get to the System Information page from the Settings menu (cog icon).

In day-to-day operations using Mycodo, an easy link back to your preferred landing page seems to make more sense than going to the System Information page.

If you think this change requires another configuration setting similar to what's used for the Landing Page, we can go that route, too.