### PR TITLE
Fix dependency name (framebuf) for CircuitPython SD1306 devices

### DIFF
--- a/mycodo/config.py
+++ b/mycodo/config.py
@@ -127,7 +127,7 @@ LCD_INFO = {
         'dependencies_module': [
             ('apt', 'libjpeg-dev', 'libjpeg-dev'),
             ('pip-pypi', 'PIL', 'Pillow'),
-            ('pip-pypi', 'adafruit_framebuf', 'Adafruit-Circuitpython-Framebuff'),
+            ('pip-pypi', 'adafruit_framebuf', 'adafruit-circuitpython-framebuf'),
             ('pip-pypi', 'adafruit_ssd1306', 'Adafruit-Circuitpython-SSD1306'),
             ('pip-pypi', 'adafruit_extended_bus', 'Adafruit_Extended_Bus')
         ],
@@ -139,7 +139,7 @@ LCD_INFO = {
         'dependencies_module': [
             ('apt', 'libjpeg-dev', 'libjpeg-dev'),
             ('pip-pypi', 'PIL', 'Pillow'),
-            ('pip-pypi', 'adafruit_framebuf', 'Adafruit-Circuitpython-Framebuff'),
+            ('pip-pypi', 'adafruit_framebuf', 'adafruit-circuitpython-framebuf'),
             ('pip-pypi', 'adafruit_ssd1306', 'Adafruit-Circuitpython-SSD1306'),
             ('pip-pypi', 'adafruit_extended_bus', 'Adafruit_Extended_Bus')
         ],


### PR DESCRIPTION
This fix corrects the CircuitPython `framebuf` module dependency for SD1306 LCDs.

The correct dependency to install is `adafruit-circuitpython-framebuf`, not `Adafruit-Circuitpython-Framebuff`.