### PR TITLE
Fix INA219x sensor i2c bus initialization

### DIFF
--- a/mycodo/inputs/ina219x.py
+++ b/mycodo/inputs/ina219x.py
@@ -138,7 +138,8 @@ INPUT_INFORMATION = {
 
     # adafruit-circuitpython-ina219 also installs adafruit-blinka
     'dependencies_module': [
-        ('pip-pypi', 'adafruit_ina219', 'adafruit-circuitpython-ina219')
+        ('pip-pypi', 'adafruit_ina219', 'adafruit-circuitpython-ina219'),
+        ('pip-pypi', 'adafruit_extended_bus', 'Adafruit_Extended_Bus')
     ],
 
     'interfaces': ['I2C'],
@@ -225,13 +226,11 @@ class InputModule(AbstractInput):
         """
         Initialize INA219x sensor
         """
-        import board
         from adafruit_ina219 import INA219, ADCResolution, BusVoltageRange
-
-        i2c_bus = board.I2C()
+        from adafruit_extended_bus import ExtendedI2C
 
         try:
-            self.sensor = INA219(i2c_bus,
+            self.sensor = INA219(ExtendedI2C(self.input_dev.i2c_bus),
                 addr=int(str(self.input_dev.i2c_location), 16))
         except (ValueError, OSError) as msg:
             self.logger.exception("INA219x Exception: %s", msg)


### PR DESCRIPTION
Hi, 
I'm using TCA9548A multiplexer so I need to set the specific i2c bus for INA219 sensor. I found that the current INA219 sensor module implementation doesn't take into account i2c bus selected in the configuration, but using the default board i2c instead. This PR fixes the problem using adafruit_extended_bus library (same as in other modules).

Thanks and keep up your GREAT work :+1: