### PR TITLE
Add support for adafruit i2c capacitive soil moisture sensor

### DIFF
--- a/mycodo/inputs/adafruit_i2c_soil.py
+++ b/mycodo/inputs/adafruit_i2c_soil.py
@@ -42,7 +42,7 @@ INPUT_INFORMATION = {
     ],
 
     'interfaces': ['I2C'],
-    'i2c_location': ['0x36'],
+    'i2c_location': ['0x36','0x37','0x38','0x39'],
     'i2c_address_editable': False
 }
 


### PR DESCRIPTION
It seems my main change on this sneaked in already with https://github.com/kizniche/Mycodo/pull/957
I was not aware that any changes I do in my fork after requesting a PR but before it is merged are automatically amended to the existing PR. Hope you also agree to have this device included.
This PR is just one little extension to allow the 4 different i2c addresses the sensor supports via solder jumpers. They are not documented so I tried all combinations with my device manually.
