### PR TITLE
saving upgrade_commands.sh changes

### DIFF
--- a/mycodo/scripts/upgrade_commands.sh
+++ b/mycodo/scripts/upgrade_commands.sh
@@ -293,7 +293,7 @@ case "${1:-''}" in
         make install
         cd "${MYCODO_PATH}"/install || return
         rm -rf ./PIGPIO
-        rm -rf pigpio-latest.tar.gz
+        rm -rf pigpio.tar.gz
         /bin/bash "${MYCODO_PATH}"/mycodo/scripts/upgrade_commands.sh disable-pigpiod
         /bin/bash "${MYCODO_PATH}"/mycodo/scripts/upgrade_commands.sh enable-pigpiod-high
         mkdir -p /opt/mycodo
@@ -312,7 +312,7 @@ case "${1:-''}" in
         make uninstall
         cd "${MYCODO_PATH}"/install || return
         rm -rf ./PIGPIO
-        rm -rf pigpio-latest.tar.gz
+        rm -rf pigpio.tar.gz
         touch /etc/systemd/system/pigpiod_uninstalled.service
         rm -f /opt/mycodo/pigpio_installed
     ;;

--- a/mycodo/scripts/upgrade_commands.sh
+++ b/mycodo/scripts/upgrade_commands.sh
@@ -14,8 +14,7 @@ fi
 MYCODO_MAJOR_VERSION="8"
 
 # Dependency versions/URLs
-#PIGPIO_URL="https://github.com/joan2937/pigpio/archive/v77.tar.gz"
-PIGPIO_URL="https://github.com/joan2937/pigpio/archive/master.zip"
+PIGPIO_URL="https://github.com/joan2937/pigpio/archive/v79.tar.gz"
 MCB2835_URL="http://www.airspayce.com/mikem/bcm2835/bcm2835-1.50.tar.gz"
 WIRINGPI_URL="https://project-downloads.drogon.net/wiringpi-latest.deb"
 INFLUXDB_VERSION="1.8.0"
@@ -286,21 +285,15 @@ case "${1:-''}" in
         apt-get install -y python3-pigpio
         cd "${MYCODO_PATH}"/install || return
         # wget --quiet -P "${MYCODO_PATH}"/install abyz.co.uk/rpi/pigpio/pigpio.zip
-#        wget ${PIGPIO_URL} -O pigpio.tar.gz
-#        mkdir PIGPIO
-#        tar xzf pigpio.tar.gz -C PIGPIO --strip-components=1
-        wget ${PIGPIO_URL}
-        unzip master.zip
-#        cd "${MYCODO_PATH}"/install/PIGPIO || return
-        cd "${MYCODO_PATH}"/install/pigpio-master || return
-#        make -j4
-        make
+        wget ${PIGPIO_URL} -O pigpio.tar.gz
+        mkdir PIGPIO
+        tar xzf pigpio.tar.gz -C PIGPIO --strip-components=1
+        cd "${MYCODO_PATH}"/install/PIGPIO || return
+        make -j4
         make install
         cd "${MYCODO_PATH}"/install || return
-#        rm -rf ./PIGPIO
-        rm -rf ./pigpio-master
-#        rm -rf pigpio-latest.tar.gz
-        rm -rf master.zip
+        rm -rf ./PIGPIO
+        rm -rf pigpio-latest.tar.gz
         /bin/bash "${MYCODO_PATH}"/mycodo/scripts/upgrade_commands.sh disable-pigpiod
         /bin/bash "${MYCODO_PATH}"/mycodo/scripts/upgrade_commands.sh enable-pigpiod-high
         mkdir -p /opt/mycodo
@@ -312,20 +305,14 @@ case "${1:-''}" in
         apt-get install -y jq
         cd "${MYCODO_PATH}"/install || return
         # wget --quiet -P "${MYCODO_PATH}"/install abyz.co.uk/rpi/pigpio/pigpio.zip
-#        wget ${PIGPIO_URL} -O pigpio.tar.gz
-#        mkdir PIGPIO
-#        tar xzf pigpio.tar.gz -C PIGPIO --strip-components=1
-        wget ${PIGPIO_URL}
-        unzip master.zip
-#        cd pigpio-master
-#        cd "${MYCODO_PATH}"/install/PIGPIO || return
-        cd "${MYCODO_PATH}"/install/pigpio-master || return
+        wget ${PIGPIO_URL} -O pigpio.tar.gz
+        mkdir PIGPIO
+        tar xzf pigpio.tar.gz -C PIGPIO --strip-components=1
+        cd "${MYCODO_PATH}"/install/PIGPIO || return
         make uninstall
         cd "${MYCODO_PATH}"/install || return
-#        rm -rf ./PIGPIO
-#        rm -rf pigpio-latest.tar.gz
-        rm -rf ./pigpio-master
-        rm -rf master.zip
+        rm -rf ./PIGPIO
+        rm -rf pigpio-latest.tar.gz
         touch /etc/systemd/system/pigpiod_uninstalled.service
         rm -f /opt/mycodo/pigpio_installed
     ;;

--- a/mycodo/scripts/upgrade_commands.sh
+++ b/mycodo/scripts/upgrade_commands.sh
@@ -14,7 +14,8 @@ fi
 MYCODO_MAJOR_VERSION="8"
 
 # Dependency versions/URLs
-PIGPIO_URL="https://github.com/joan2937/pigpio/archive/v77.tar.gz"
+#PIGPIO_URL="https://github.com/joan2937/pigpio/archive/v77.tar.gz"
+PIGPIO_URL="https://github.com/joan2937/pigpio/archive/master.zip"
 MCB2835_URL="http://www.airspayce.com/mikem/bcm2835/bcm2835-1.50.tar.gz"
 WIRINGPI_URL="https://project-downloads.drogon.net/wiringpi-latest.deb"
 INFLUXDB_VERSION="1.8.0"
@@ -285,15 +286,21 @@ case "${1:-''}" in
         apt-get install -y python3-pigpio
         cd "${MYCODO_PATH}"/install || return
         # wget --quiet -P "${MYCODO_PATH}"/install abyz.co.uk/rpi/pigpio/pigpio.zip
-        wget ${PIGPIO_URL} -O pigpio.tar.gz
-        mkdir PIGPIO
-        tar xzf pigpio.tar.gz -C PIGPIO --strip-components=1
-        cd "${MYCODO_PATH}"/install/PIGPIO || return
-        make -j4
+#        wget ${PIGPIO_URL} -O pigpio.tar.gz
+#        mkdir PIGPIO
+#        tar xzf pigpio.tar.gz -C PIGPIO --strip-components=1
+        wget ${PIGPIO_URL}
+        unzip master.zip
+#        cd "${MYCODO_PATH}"/install/PIGPIO || return
+        cd "${MYCODO_PATH}"/install/pigpio-master || return
+#        make -j4
+        make
         make install
         cd "${MYCODO_PATH}"/install || return
-        rm -rf ./PIGPIO
-        rm -rf pigpio-latest.tar.gz
+#        rm -rf ./PIGPIO
+        rm -rf ./pigpio-master
+#        rm -rf pigpio-latest.tar.gz
+        rm -rf master.zip
         /bin/bash "${MYCODO_PATH}"/mycodo/scripts/upgrade_commands.sh disable-pigpiod
         /bin/bash "${MYCODO_PATH}"/mycodo/scripts/upgrade_commands.sh enable-pigpiod-high
         mkdir -p /opt/mycodo
@@ -305,14 +312,20 @@ case "${1:-''}" in
         apt-get install -y jq
         cd "${MYCODO_PATH}"/install || return
         # wget --quiet -P "${MYCODO_PATH}"/install abyz.co.uk/rpi/pigpio/pigpio.zip
-        wget ${PIGPIO_URL} -O pigpio.tar.gz
-        mkdir PIGPIO
-        tar xzf pigpio.tar.gz -C PIGPIO --strip-components=1
-        cd "${MYCODO_PATH}"/install/PIGPIO || return
+#        wget ${PIGPIO_URL} -O pigpio.tar.gz
+#        mkdir PIGPIO
+#        tar xzf pigpio.tar.gz -C PIGPIO --strip-components=1
+        wget ${PIGPIO_URL}
+        unzip master.zip
+#        cd pigpio-master
+#        cd "${MYCODO_PATH}"/install/PIGPIO || return
+        cd "${MYCODO_PATH}"/install/pigpio-master || return
         make uninstall
         cd "${MYCODO_PATH}"/install || return
-        rm -rf ./PIGPIO
-        rm -rf pigpio-latest.tar.gz
+#        rm -rf ./PIGPIO
+#        rm -rf pigpio-latest.tar.gz
+        rm -rf ./pigpio-master
+        rm -rf master.zip
         touch /etc/systemd/system/pigpiod_uninstalled.service
         rm -f /opt/mycodo/pigpio_installed
     ;;


### PR DESCRIPTION
Fixed pigpio installation and removal bash script to reflect changes by pigpio author. New installation instructions found here:
http://abyz.me.uk/rpi/pigpio/download.html

Left code commented for comparison and feedback.