### PR TITLE
Optimize timelapse and still retrieval

### DIFF
--- a/databases/alembic/versions/0187ea22dc4b_add_camera_file_tracking_fields.py
+++ b/databases/alembic/versions/0187ea22dc4b_add_camera_file_tracking_fields.py
@@ -1,0 +1,32 @@
+"""add camera file tracking fields
+
+Revision ID: 0187ea22dc4b
+Revises: 6e394f2e8fec
+Create Date: 2021-09-03 12:08:49.777948
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0187ea22dc4b"
+down_revision = "6e394f2e8fec"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("camera") as batch_op:
+        batch_op.add_column(sa.Column("timelapse_last_file", sa.Text))
+        batch_op.add_column(sa.Column("timelapse_last_ts", sa.Float))
+        batch_op.add_column(sa.Column("still_last_file", sa.Text))
+        batch_op.add_column(sa.Column("still_last_ts", sa.Float))
+
+
+def downgrade():
+    with op.batch_alter_table("camera") as batch_op:
+        batch_op.drop_column("timelapse_last_file")
+        batch_op.drop_column("timelapse_last_ts")
+        batch_op.drop_column("still_last_file")
+        batch_op.drop_column("still_last_ts")

--- a/mycodo/databases/models/camera.py
+++ b/mycodo/databases/models/camera.py
@@ -43,6 +43,12 @@ class Camera(CRUDMixin, db.Model):
     timelapse_interval = db.Column(db.Float, default=None)
     timelapse_next_capture = db.Column(db.Float, default=None)
     timelapse_capture_number = db.Column(db.Integer, default=None)
+    timelapse_last_file = db.Column(db.Text, default=None)
+    timelapse_last_ts = db.Column(db.Float, default=None)
+
+    # Still tracking
+    still_last_file = db.Column(db.Text, default=None)
+    still_last_ts = db.Column(db.Float, default=None)
 
     # Paths
     path_still = db.Column(db.Text, default='')

--- a/mycodo/mycodo_flask/routes_general.py
+++ b/mycodo/mycodo_flask/routes_general.py
@@ -184,7 +184,8 @@ def camera_img_latest_timelapse(camera_unique_id, max_age):
     if camera.timelapse_last_file is not None and os.path.exists(timelapse_file_path):
         time_max_age = datetime.datetime.now() - datetime.timedelta(seconds=int(max_age))
         if datetime.datetime.fromtimestamp(camera.timelapse_last_ts) > time_max_age:
-            return_values = '["{}","{}"]'.format(camera.timelapse_last_file, camera_unique_id)
+            ts = datetime.datetime.fromtimestamp(camera.timelapse_last_ts).strftime("%Y-%m-%d %H:%M:%S")
+            return_values = '["{}","{}"]'.format(camera.timelapse_last_file, ts)
         else:
             return_values = '["max_age_exceeded"]'
     else:

--- a/mycodo/mycodo_flask/routes_general.py
+++ b/mycodo/mycodo_flask/routes_general.py
@@ -184,7 +184,7 @@ def camera_img_latest_timelapse(camera_unique_id, max_age):
     if camera.timelapse_last_file is not None and os.path.exists(timelapse_file_path):
         time_max_age = datetime.datetime.now() - datetime.timedelta(seconds=int(max_age))
         if datetime.datetime.fromtimestamp(camera.timelapse_last_ts) > time_max_age:
-            return_values = '["{}","{}"]'.format(timelapse_file_path, camera_unique_id)
+            return_values = '["{}","{}"]'.format(camera.timelapse_last_file, camera_unique_id)
         else:
             return_values = '["max_age_exceeded"]'
     else:

--- a/mycodo/mycodo_flask/utils/utils_general.py
+++ b/mycodo/mycodo_flask/utils/utils_general.py
@@ -1594,7 +1594,7 @@ def get_camera_image_info():
 
         except ValueError:
             latest_time_lapse_img_full_path = None
-         if each_camera.timelapse_last_file:
+        if each_camera.timelapse_last_file:
             latest_img_tl_ts[each_camera.unique_id] = datetime.fromtimestamp(
                 each_camera.timelapse_last_ts).strftime("%Y-%m-%d %H:%M:%S")
             latest_img_tl[each_camera.unique_id] = each_camera.timelapse_last_file


### PR DESCRIPTION
Resolves https://github.com/kizniche/Mycodo/issues/1086

This records the filename and timestamp of still and timelapse images in the database as they are generated and references that instead of scanning the filesystem for the newest of either. This should reduce load times for the camera administration page as well as dashboards with camera widgets showing recent images, especially when there are many files it would otherwise need to parse through.

`get_camera_image_info` still does a `listdir` on the filesystem for the array of timelapse images which I think could be optimized somehow (probably moved into its own method and called separately), but that's just a single call to list the directory contents whereas the checks for recent stills/timelapses would run a check for the mtime on each file separately which is where the bulk of load time comes from.