### PR TITLE
Update bme680_circuitpython.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,3 +229,13 @@ docs-old/_build/
 
 # PyBuilder
 target/
+
+#to make clean repo
+mycodo/flask_session/  
+mycodo/mycodo_flask/templates/user_templates/
+.dependency
+install/wiringpi-latest.deb
+mycodo/mycodo_flask/ssl_certs/server.crt
+mycodo/mycodo_flask/ssl_certs/server.csr
+mycodo/mycodo_flask/ssl_certs/server.key
+mycodo/scripts/mycodo_wrapper

--- a/mycodo/inputs/bme680_circuitpython.py
+++ b/mycodo/inputs/bme680_circuitpython.py
@@ -65,7 +65,7 @@ INPUT_INFORMATION = {
     'dependencies_module': [
         ('pip-pypi', 'usb.core', 'pyusb==1.1.1'),
         ('pip-pypi', 'adafruit_extended_bus', 'Adafruit-extended-bus==1.0.2'),
-        ('pip-pypi', 'adafruit_bme680', 'adafruit-circuitpython-bme680==2.5.4')
+        ('pip-pypi', 'adafruit_bme680', 'adafruit-circuitpython-bme680')
     ],
 
     'interfaces': ['I2C'],

--- a/mycodo/inputs/bme680_circuitpython.py
+++ b/mycodo/inputs/bme680_circuitpython.py
@@ -65,7 +65,7 @@ INPUT_INFORMATION = {
     'dependencies_module': [
         ('pip-pypi', 'usb.core', 'pyusb==1.1.1'),
         ('pip-pypi', 'adafruit_extended_bus', 'Adafruit-extended-bus==1.0.2'),
-        ('pip-pypi', 'adafruit_bme680', 'adafruit-circuitpython-bme680')
+        ('pip-pypi', 'adafruit_bme680', 'adafruit-circuitpython-bme680==3.4.1')
     ],
 
     'interfaces': ['I2C'],

--- a/mycodo/inputs/scd4x_circuitpython.py
+++ b/mycodo/inputs/scd4x_circuitpython.py
@@ -51,7 +51,7 @@ INPUT_INFORMATION = {
     'dependencies_module': [
         ('pip-pypi', 'usb.core', 'pyusb==1.1.1'),
         ('pip-pypi', 'adafruit_extended_bus', 'Adafruit-extended-bus==1.0.2'),
-        ('pip-pypi', 'adafruit_scd4x', 'adafruit-circuitpython-scd4x==3.4.1')
+        ('pip-pypi', 'adafruit_scd4x', 'adafruit-circuitpython-scd4x==1.2.2')
     ],
 
     'interfaces': ['I2C'],

--- a/mycodo/inputs/scd4x_circuitpython.py
+++ b/mycodo/inputs/scd4x_circuitpython.py
@@ -51,7 +51,7 @@ INPUT_INFORMATION = {
     'dependencies_module': [
         ('pip-pypi', 'usb.core', 'pyusb==1.1.1'),
         ('pip-pypi', 'adafruit_extended_bus', 'Adafruit-extended-bus==1.0.2'),
-        ('pip-pypi', 'adafruit_scd4x', 'adafruit-circuitpython-scd4x==1.2.2')
+        ('pip-pypi', 'adafruit_scd4x', 'adafruit-circuitpython-scd4x==3.4.1')
     ],
 
     'interfaces': ['I2C'],


### PR DESCRIPTION
Errored on dependency install library install adafruit-circuitpython-bme680==2.5.4
Could not find library on pypi with that version number
Removed required version number. 