### PR TITLE
Fixed any output using 'select_channel' when used in actions

### DIFF
--- a/mycodo/abstract_base_controller.py
+++ b/mycodo/abstract_base_controller.py
@@ -264,6 +264,10 @@ class AbstractBaseController(object):
                     setattr(self, f"{each_option_default['id']}_device_id", device_id)
                     setattr(self, f"{each_option_default['id']}_measurement_id", measurement_id)
 
+                elif each_option_default['type'] == 'select_channel':
+                    setattr(self, f"{each_option_default['id']}_device_id", device_id)
+                    setattr(self, f"{each_option_default['id']}_channel_id", channel_id)
+
                 elif each_option_default['type'] == 'select_measurement_channel':
                     setattr(self, f"{each_option_default['id']}_device_id", device_id)
                     setattr(self, f"{each_option_default['id']}_measurement_id", measurement_id)
@@ -280,10 +284,6 @@ class AbstractBaseController(object):
 
                 elif each_option_default['type'] in ['message', 'new_line']:
                     pass
-
-                elif each_option_default['type'] == 'select_channel':
-                    setattr(self, f"{each_option_default['id']}_device_id", device_id)
-                    setattr(self, f"{each_option_default['id']}_channel_id", channel_id)
 
                 else:
                     self.logger.error(

--- a/mycodo/abstract_base_controller.py
+++ b/mycodo/abstract_base_controller.py
@@ -281,6 +281,10 @@ class AbstractBaseController(object):
                 elif each_option_default['type'] in ['message', 'new_line']:
                     pass
 
+                elif each_option_default['type'] == 'select_channel':
+                    setattr(self, f"{each_option_default['id']}_device_id", device_id)
+                    setattr(self, f"{each_option_default['id']}_channel_id", channel_id)
+
                 else:
                     self.logger.error(
                         f"setup_custom_options_json() Unknown option type '{each_option_default['type']}'")


### PR DESCRIPTION
Error occurs when trying to use an output using 'select_channel' from actions, in my case an HS300 power strip.

Error Logs

```
2022-03-12 22:03:07,184 - ERROR - mycodo.function_action.output_on_off_a52d7e4c - setup_custom_options_json() Unknown option type 'select_channel'

2022-03-12 22:03:07,238 - DEBUG - mycodo.function_action.output_on_off_a52d7e4c - Message: 2022-03-12 22:03:06
[Trigger 96d044dd-e2ee-4da6-a446-c085982d728c (Trigger: Timer (Duration))]
[Action a52d7e4c, Output: On/Off/Duration]: Turn output None CHNone (Power Strip) on for 5.0 seconds.

2022-03-12 22:03:07,239 - DEBUG - mycodo.trigger_action_a52d7e4c - Message: 2022-03-12 22:03:06
[Trigger 96d044dd-e2ee-4da6-a446-c085982d728c (Trigger: Timer (Duration))]
[Action a52d7e4c, Output: On/Off/Duration]: Turn output None CHNone (Power Strip) on for 5.0 seconds.

2022-03-12 22:03:07,246 - ERROR - mycodo.controllers.controller_output - Output None not found

2022-03-12 22:03:07,246 - DEBUG - mycodo.trigger_function_actions_96d044dd - Message: 2022-03-12 22:03:06
[Trigger 96d044dd-e2ee-4da6-a446-c085982d728c (Trigger: Timer (Duration))]
[Action a52d7e4c, Output: On/Off/Duration]: Turn output None CHNone (Power Strip) on for 5.0 seconds.
```
```