### PR TITLE
Add Websocket support to MQTT connections

### DIFF
--- a/mycodo/actions/mqtt_publish.py
+++ b/mycodo/actions/mqtt_publish.py
@@ -115,6 +115,14 @@ ACTION_INFORMATION = {
             'required': False,
             'name': lazy_gettext('Password'),
             'phrase': 'Password for connecting to the server'
+        },
+        {
+            'id': 'mqtt_use_websockets',
+            'type': 'bool',
+            'default_value': False,
+            'required': False,
+            'name': 'Use Websockets',
+            'phrase': 'Use websockets to connect to the server.'
         }
     ]
 }
@@ -137,6 +145,7 @@ class ActionModule(AbstractFunctionAction):
         self.login = None
         self.username = None
         self.password = None
+        self.mqtt_use_websockets = None
 
         action = db_retrieve_table_daemon(
             Actions, unique_id=self.unique_id)
@@ -193,7 +202,8 @@ class ActionModule(AbstractFunctionAction):
                 port=self.port,
                 client_id=self.clientid,
                 keepalive=self.keepalive,
-                auth=auth_dict)
+                auth=auth_dict,
+                transport='websockets' if self.mqtt_use_websockets else 'tcp')
             message += f" MQTT Publish '{payload}'."
         except Exception as err:
             msg = f" Could not execute MQTT Publish: {err}"

--- a/mycodo/actions/mqtt_publish_input.py
+++ b/mycodo/actions/mqtt_publish_input.py
@@ -99,6 +99,14 @@ ACTION_INFORMATION = {
             'required': False,
             'name': lazy_gettext('Password'),
             'phrase': 'Password for connecting to the server.'
+        },
+        {
+            'id': 'mqtt_use_websockets',
+            'type': 'bool',
+            'default_value': False,
+            'required': False,
+            'name': 'Use Websockets',
+            'phrase': 'Use websockets to connect to the server.'
         }
     ]
 }
@@ -122,6 +130,7 @@ class ActionModule(AbstractFunctionAction):
         self.login = None
         self.username = None
         self.password = None
+        self.mqtt_use_websockets = None
 
         action = db_retrieve_table_daemon(
             Actions, unique_id=self.unique_id)
@@ -175,7 +184,8 @@ class ActionModule(AbstractFunctionAction):
                 port=self.port,
                 client_id=self.clientid,
                 keepalive=self.keepalive,
-                auth=auth_dict)
+                auth=auth_dict,
+                transport='websockets' if self.mqtt_use_websockets else 'tcp')
             message += f" MQTT Publish '{payload}'."
         except Exception as err:
             msg = f" Could not execute MQTT Publish: {err}"

--- a/mycodo/inputs/mqtt_paho.py
+++ b/mycodo/inputs/mqtt_paho.py
@@ -117,6 +117,14 @@ INPUT_INFORMATION = {
             'required': False,
             'name': lazy_gettext('Password'),
             'phrase': 'Password for connecting to the server. Leave blank to disable.'
+        },
+        {
+            'id': 'mqtt_use_websockets',
+            'type': 'bool',
+            'default_value': False,
+            'required': False,
+            'name': 'Use Websockets',
+            'phrase': 'Use websockets to connect to the server.'
         }
     ],
 
@@ -158,6 +166,7 @@ class InputModule(AbstractInput):
         self.mqtt_use_tls = None
         self.mqtt_username = None
         self.mqtt_password = None
+        self.mqtt_use_websockets = None
 
         if not testing:
             self.setup_custom_options(
@@ -172,7 +181,9 @@ class InputModule(AbstractInput):
         self.options_channels = self.setup_custom_channel_options_json(
             INPUT_INFORMATION['custom_channel_options'], input_channels)
 
-        self.client = mqtt.Client(self.mqtt_clientid)
+        self.client = mqtt.Client(
+            self.mqtt_clientid,
+            transport='websockets' if self.mqtt_use_websockets else 'tcp')
         self.logger.debug("Client created with ID {}".format(self.mqtt_clientid))
         if self.mqtt_login:
             if not self.mqtt_password:

--- a/mycodo/inputs/mqtt_paho_json.py
+++ b/mycodo/inputs/mqtt_paho_json.py
@@ -133,6 +133,14 @@ INPUT_INFORMATION = {
             'required': False,
             'name': lazy_gettext('Password'),
             'phrase': 'Password for connecting to the server. Leave blank to disable.'
+        },
+        {
+            'id': 'mqtt_use_websockets',
+            'type': 'bool',
+            'default_value': False,
+            'required': False,
+            'name': 'Use Websockets',
+            'phrase': 'Use websockets to connect to the server.'
         }
     ],
 
@@ -176,6 +184,7 @@ class InputModule(AbstractInput):
         self.mqtt_use_tls = None
         self.mqtt_username = None
         self.mqtt_password = None
+        self.mqtt_use_websockets = None
 
         if not testing:
             self.setup_custom_options(
@@ -193,7 +202,9 @@ class InputModule(AbstractInput):
         self.options_channels = self.setup_custom_channel_options_json(
             INPUT_INFORMATION['custom_channel_options'], input_channels)
 
-        self.client = mqtt.Client(self.mqtt_clientid)
+        self.client = mqtt.Client(
+            self.mqtt_clientid,
+            transport='websockets' if self.mqtt_use_websockets else 'tcp')
         self.logger.debug("Client created with ID {}".format(self.mqtt_clientid))
         if self.mqtt_login:
             if not self.mqtt_password:

--- a/mycodo/outputs/on_off_mqtt.py
+++ b/mycodo/outputs/on_off_mqtt.py
@@ -168,6 +168,14 @@ OUTPUT_INFORMATION = {
             'required': False,
             'name': lazy_gettext('Password'),
             'phrase': 'Password for connecting to the server. Leave blank to disable.'
+        },
+        {
+            'id': 'mqtt_use_websockets',
+            'type': 'bool',
+            'default_value': False,
+            'required': False,
+            'name': 'Use Websockets',
+            'phrase': 'Use websockets to connect to the server.'
         }
     ]
 }
@@ -217,7 +225,8 @@ class OutputModule(AbstractOutput):
                     port=self.options_channels['port'][0],
                     client_id=self.options_channels['clientid'][0],
                     keepalive=self.options_channels['keepalive'][0],
-                    auth=auth_dict)
+                    auth=auth_dict,
+                    transport='websockets' if self.options_channels['mqtt_use_websockets'][0] else 'tcp')
                 self.output_states[output_channel] = True
             elif state == 'off':
                 self.publish.single(
@@ -227,7 +236,8 @@ class OutputModule(AbstractOutput):
                     port=self.options_channels['port'][0],
                     client_id=self.options_channels['clientid'][0],
                     keepalive=self.options_channels['keepalive'][0],
-                    auth=auth_dict)
+                    auth=auth_dict,
+                    transport='websockets' if self.options_channels['mqtt_use_websockets'][0] else 'tcp')
                 self.output_states[output_channel] = False
         except Exception as e:
             self.logger.error("State change error: {}".format(e))

--- a/mycodo/outputs/value_mqtt.py
+++ b/mycodo/outputs/value_mqtt.py
@@ -120,6 +120,14 @@ OUTPUT_INFORMATION = {
             'required': False,
             'name': lazy_gettext('Password'),
             'phrase': 'Password for connecting to the server.'
+        },
+        {
+            'id': 'mqtt_use_websockets',
+            'type': 'bool',
+            'default_value': False,
+            'required': False,
+            'name': 'Use Websockets',
+            'phrase': 'Use websockets to connect to the server.'
         }
     ]
 }
@@ -166,7 +174,8 @@ class OutputModule(AbstractOutput):
                     port=self.options_channels['port'][0],
                     client_id=self.options_channels['clientid'][0],
                     keepalive=self.options_channels['keepalive'][0],
-                    auth=auth_dict)
+                    auth=auth_dict,
+                    transport='websockets' if self.options_channels['mqtt_use_websockets'][0] else 'tcp')
                 self.output_states[output_channel] = amount
                 measure_dict[0]['value'] = amount
             elif state == 'off':
@@ -177,7 +186,8 @@ class OutputModule(AbstractOutput):
                     port=self.options_channels['port'][0],
                     client_id=self.options_channels['clientid'][0],
                     keepalive=self.options_channels['keepalive'][0],
-                    auth=auth_dict)
+                    auth=auth_dict,
+                    transport='websockets' if self.options_channels['mqtt_use_websockets'][0] else 'tcp')
                 self.output_states[output_channel] = False
                 measure_dict[0]['value'] = self.options_channels['off_value'][0]
         except Exception as e:


### PR DESCRIPTION
Add Websockets support to MQTT connections.
Or rather, make it possible to enable Websockets since `paho-mqtt` already supports them.