### PR TITLE
Fix for Kasa plugs in on_off_kasa_plugs.py

### DIFF
--- a/mycodo/outputs/on_off_kasa_plugs.py
+++ b/mycodo/outputs/on_off_kasa_plugs.py
@@ -195,7 +195,7 @@ class OutputModule(AbstractOutput):
                 self.status_thread = Thread(target=self.status_update)
                 self.status_thread.start()
 
-    def aio_rpc_server(self, started_evt, loop, logger):
+    def aio_rpc_server(self, started_evt, loop, logger, channel_count):
         import aio_msgpack_rpc
         from kasa import SmartPlug
 


### PR DESCRIPTION
Hi there,
i think i have fixed a bug with Kasa plugs which did not work for me. When creating a "[IP] On/Off: Kasa WiFi Power Plug" output, configuring it always failed with a daemon connection timeout. No useful info in the logs, especially no loggging output from the output module. So I examined the module code and there's a simple fix.

The "aio_rpc_server" thread is passed four arguments in line 176/177, but the "aio_rpc_server()" function only uses/accepts three arguments.
This results in the rpc server to not start at all and leaving no log error whatsoever. The output setup will fail and a Kasa plugs cannot be controlled.
By adding a fourth argument "channel_count" the rpc server is started correctly and the output module for Kasa plugs is working fine.
It should be noted that new argument is never used but turning on/off the plugs works fine.

I am using and have tested this with two Kasa Plugs KP105. 
Mycodo Version: 8.14.1
Python Version: 3.9.2
python-kasa 0.5.0