### PR TITLE
Fix for Issue #1234

### DIFF
--- a/mycodo/inputs/scd4x_circuitpython.py
+++ b/mycodo/inputs/scd4x_circuitpython.py
@@ -197,7 +197,7 @@ class InputModule(AbstractInput):
             self.logger.error("CO2 Concentration required")
             return
         try:
-            self.sensor.force_calibration(float(args_dict['co2_concentration']))
+            self.sensor.force_calibration(int(args_dict['co2_concentration']))
         except Exception as err:
             self.logger.error(
                 "Error setting CO2 Concentration: {}".format(err))


### PR DESCRIPTION
Convert type of value being passed to force_calibration method from `float` to `int` as expected from the library:

https://github.com/adafruit/Adafruit_CircuitPython_SCD4X/blob/a9ae07d8c30c45e7a36d5308bdaaa2887c3c7e31/adafruit_scd4x.py#L161