### PR TITLE
Solution to Issue #1234

### DIFF
--- a/mycodo/inputs/scd4x_circuitpython.py
+++ b/mycodo/inputs/scd4x_circuitpython.py
@@ -62,7 +62,7 @@ INPUT_INFORMATION = {
     'custom_commands': [
         {
             'type': 'message',
-            'default_value': """You can force the CO2 calibration for a specific CO2 concentration value (in ppmv)."""
+            'default_value': """You can force the CO2 calibration for a specific CO2 concentration value (in ppmv). The sensor needs to be active for at least 3 minutes prior to calibration."""
         },
         {
             'id': 'co2_concentration',

--- a/mycodo/inputs/scd4x_circuitpython.py
+++ b/mycodo/inputs/scd4x_circuitpython.py
@@ -197,7 +197,8 @@ class InputModule(AbstractInput):
             self.logger.error("CO2 Concentration required")
             return
         try:
-            self.sensor.force_calibration(float(args_dict['co2_concentration']))
+            self.sensor.force_calibration(int(args_dict['co2_concentration']))
+            self.sensor.start_periodic_measurement()
         except Exception as err:
             self.logger.error(
                 "Error setting CO2 Concentration: {}".format(err))


### PR DESCRIPTION
Change argument passed to force_calibration method from float to int. The library is expecting an int as can be seen here: https://github.com/adafruit/Adafruit_CircuitPython_SCD4X/blob/a9ae07d8c30c45e7a36d5308bdaaa2887c3c7e31/adafruit_scd4x.py#L161

This fix restarts the device so that it automatically starts working without needing to deactivate and activate after force calibrating CO2.

NOTE: The adafruit library calls `sensor.stop_periodic_measurement()` at the begining of the function but never calls `sensor.start_periodic_measurement()` after it submits the calibration.