### PR TITLE
Generic LCD Function Bug

### DIFF
--- a/mycodo/functions/display_generic_lcd_16x2_i2c.py
+++ b/mycodo/functions/display_generic_lcd_16x2_i2c.py
@@ -284,7 +284,7 @@ FUNCTION_INFORMATION = {
         },
         {
             'id': 'measure_max_age',
-            'type': 'float',
+            'type': 'integer',
             'default_value': 360,
             'required': True,
             'constraints_pass': constraints_pass_positive_value,

--- a/mycodo/functions/display_generic_lcd_20x4_i2c.py
+++ b/mycodo/functions/display_generic_lcd_20x4_i2c.py
@@ -269,7 +269,7 @@ FUNCTION_INFORMATION = {
         },
         {
             'id': 'measure_max_age',
-            'type': 'float',
+            'type': 'integer',
             'default_value': 360,
             'required': True,
             'constraints_pass': constraints_pass_positive_value,

--- a/mycodo/functions/display_grove_lcd_16x2_i2c.py
+++ b/mycodo/functions/display_grove_lcd_16x2_i2c.py
@@ -318,7 +318,7 @@ FUNCTION_INFORMATION = {
         },
         {
             'id': 'measure_max_age',
-            'type': 'float',
+            'type': 'integer',
             'default_value': 360,
             'required': True,
             'constraints_pass': constraints_pass_positive_value,

--- a/mycodo/functions/display_ssd1306_oled_128x32_i2c.py
+++ b/mycodo/functions/display_ssd1306_oled_128x32_i2c.py
@@ -293,7 +293,7 @@ FUNCTION_INFORMATION = {
         },
         {
             'id': 'measure_max_age',
-            'type': 'float',
+            'type': 'integer',
             'default_value': 360,
             'required': True,
             'constraints_pass': constraints_pass_positive_value,

--- a/mycodo/functions/display_ssd1306_oled_128x32_i2c_2lines.py
+++ b/mycodo/functions/display_ssd1306_oled_128x32_i2c_2lines.py
@@ -293,7 +293,7 @@ FUNCTION_INFORMATION = {
         },
         {
             'id': 'measure_max_age',
-            'type': 'float',
+            'type': 'integer',
             'default_value': 360,
             'required': True,
             'constraints_pass': constraints_pass_positive_value,

--- a/mycodo/functions/display_ssd1306_oled_128x32_spi.py
+++ b/mycodo/functions/display_ssd1306_oled_128x32_spi.py
@@ -316,7 +316,7 @@ FUNCTION_INFORMATION = {
         },
         {
             'id': 'measure_max_age',
-            'type': 'float',
+            'type': 'integer',
             'default_value': 360,
             'required': True,
             'constraints_pass': constraints_pass_positive_value,

--- a/mycodo/functions/display_ssd1306_oled_128x32_spi_2lines.py
+++ b/mycodo/functions/display_ssd1306_oled_128x32_spi_2lines.py
@@ -308,7 +308,7 @@ FUNCTION_INFORMATION = {
         },
         {
             'id': 'measure_max_age',
-            'type': 'float',
+            'type': 'integer',
             'default_value': 360,
             'required': True,
             'constraints_pass': constraints_pass_positive_value,

--- a/mycodo/functions/display_ssd1306_oled_128x64_i2c.py
+++ b/mycodo/functions/display_ssd1306_oled_128x64_i2c.py
@@ -293,7 +293,7 @@ FUNCTION_INFORMATION = {
         },
         {
             'id': 'measure_max_age',
-            'type': 'float',
+            'type': 'integer',
             'default_value': 360,
             'required': True,
             'constraints_pass': constraints_pass_positive_value,

--- a/mycodo/functions/display_ssd1306_oled_128x64_i2c_4lines.py
+++ b/mycodo/functions/display_ssd1306_oled_128x64_i2c_4lines.py
@@ -293,7 +293,7 @@ FUNCTION_INFORMATION = {
         },
         {
             'id': 'measure_max_age',
-            'type': 'float',
+            'type': 'integer',
             'default_value': 360,
             'required': True,
             'constraints_pass': constraints_pass_positive_value,

--- a/mycodo/functions/display_ssd1306_oled_128x64_spi.py
+++ b/mycodo/functions/display_ssd1306_oled_128x64_spi.py
@@ -308,7 +308,7 @@ FUNCTION_INFORMATION = {
         },
         {
             'id': 'measure_max_age',
-            'type': 'float',
+            'type': 'integer',
             'default_value': 360,
             'required': True,
             'constraints_pass': constraints_pass_positive_value,

--- a/mycodo/functions/display_ssd1306_oled_128x64_spi_4lines.py
+++ b/mycodo/functions/display_ssd1306_oled_128x64_spi_4lines.py
@@ -308,7 +308,7 @@ FUNCTION_INFORMATION = {
         },
         {
             'id': 'measure_max_age',
-            'type': 'float',
+            'type': 'integer',
             'default_value': 360,
             'required': True,
             'constraints_pass': constraints_pass_positive_value,

--- a/mycodo/functions/display_ssd1309_oled_128x64_i2c.py
+++ b/mycodo/functions/display_ssd1309_oled_128x64_i2c.py
@@ -263,7 +263,7 @@ FUNCTION_INFORMATION = {
         },
         {
             'id': 'measure_max_age',
-            'type': 'float',
+            'type': 'integer',
             'default_value': 360,
             'required': True,
             'constraints_pass': constraints_pass_positive_value,

--- a/mycodo/utils/influxdb_2.py
+++ b/mycodo/utils/influxdb_2.py
@@ -145,7 +145,7 @@ def query_flux(unit, unique_id,
     query = f'from(bucket: \"{settings.measurement_db_dbname}\")'
 
     if past_sec:
-        query += f' |> range(start: -{past_sec}s)'
+        query += f' |> range(start: -{int(past_sec)}s)'
     elif start_str and end_str:
         query += f' |> range(start: {start_str}, stop: {end_str})'
     elif start_str:


### PR DESCRIPTION
Hey, I spent several hours on tracking down a bug in the generic LCD functions. Because the `measure_max_age` value is listed as a `float`, the Flux query that gets created for Influx 2.x throws an error. It requires an `integer` value.