### PR TITLE
Update ruuvitag-sensor dependency

### DIFF
--- a/mycodo/inputs/ruuvitag.py
+++ b/mycodo/inputs/ruuvitag.py
@@ -76,7 +76,7 @@ INPUT_INFORMATION = {
         ('pip-pypi', 'psutil', 'psutil==5.9.0'),
         ('apt', 'bluez', 'bluez'),
         ('apt', 'bluez-hcidump', 'bluez-hcidump'),
-        ('pip-pypi', 'ruuvitag_sensor', 'ruuvitag-sensor==1.1.0')
+        ('pip-pypi', 'ruuvitag_sensor', 'ruuvitag-sensor==2.0.0')
     ],
 
     'interfaces': ['BT'],


### PR DESCRIPTION
When using ruuvitag-sensor 1.2.0 and influxdb 2 on a 64bit platform, two conflicting versions of rx are needed. ruuvitag-sensor 2.0.0 seems to work fine.