### PR TITLE
'docker-compose ...' is now 'docker compose ...' and has different syntax

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,6 +1,9 @@
 build:
-	docker-compose up --build -d
+	docker compose build
+
+run:
+	docker compose up
 
 clean:
-	docker-compose down
+	docker compose down
 	docker system prune -a

--- a/docker/README.md
+++ b/docker/README.md
@@ -114,6 +114,12 @@ Log out then back in for the group addition to take effect.
 make build
 ```
 
+#### Run with docker-compose
+
+```shell script
+make run
+```
+
 If all goes as planned, you should have all containers build and start without issue.
 
 ## Access


### PR DESCRIPTION
Title says it all.

Perhaps install compose plugin should be added to the setup.sh


`sudo apt-get install docker-compose-plugin`

... somewhere in

`sudo /bin/bash ./setup.sh dependencies`
