### PR TITLE
Set python jsonschema version to 4.17.3 to avoid 4.18.x rust dependency

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -23,7 +23,7 @@ gunicorn==21.2.0
 importlib_metadata==6.8.0
 influxdb==5.3.1  # Only used for stats. TODO: update to influxdb_client and remove
 influxdb_client[ciso]==1.37.0
-jsonschema==4.17.3
+jsonschema==4.17.3 # Dependency of Flask_RESTX. jsonschema 4.18.x introduces Rust as a dependency. Setting version to avoid this.
 marshmallow_sqlalchemy==0.29.0
 pyro5==5.14
 pyserial==3.5

--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -23,6 +23,7 @@ gunicorn==21.2.0
 importlib_metadata==6.8.0
 influxdb==5.3.1  # Only used for stats. TODO: update to influxdb_client and remove
 influxdb_client[ciso]==1.37.0
+jsonschema==4.17.3
 marshmallow_sqlalchemy==0.29.0
 pyro5==5.14
 pyserial==3.5


### PR DESCRIPTION
When I installed Mycodo on a 32bit raspberry pi from both the latest release and master I see the following python dependency exception:


```
Collecting rpds-py>=0.7.1 (from jsonschema->Flask_RESTX==1.1.0->-r /home/pi/Mycodo/install/requirements.txt (line 16))
  Downloading rpds_py-0.9.2.tar.gz (16 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      
      Cargo, the Rust package manager, is not installed or is not on PATH.
      This package requires Rust and Cargo to compile extensions. Install it through
      the system's package manager or via https://rustup.rs/
      
      Checking for Rust toolchain....
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
```

rpds-py is a dependency of jsonschema which is a dependency of flask-restx. 

In version 4.18.x jsonschema added rust as a build dependency. Others had a similar issue here:
https://github.com/python-jsonschema/jsonschema/issues/1143


Also wanted to throw out a thank you for all the work you have put into this project! It has been very interesting to work through your build instructions this last while. Keep it up and let me know if you have any questions.
