### PR TITLE
Updated version of adafruit-circuitpython-ahtx0 library with bugfix

### DIFF
--- a/mycodo/inputs/ahtx0_circuitpython.py
+++ b/mycodo/inputs/ahtx0_circuitpython.py
@@ -36,7 +36,7 @@ INPUT_INFORMATION = {
     'dependencies_module': [
         ('pip-pypi', 'usb.core', 'pyusb==1.1.1'),
         ('pip-pypi', 'adafruit_extended_bus', 'Adafruit-extended-bus==1.0.2'),
-        ('pip-pypi', 'adafruit_ahtx0', 'adafruit-circuitpython-ahtx0==1.0.5')
+        ('pip-pypi', 'adafruit_ahtx0', 'adafruit-circuitpython-ahtx0==1.0.21')
     ],
 
     'interfaces': ['I2C'],


### PR DESCRIPTION
Newer AHT20s do not work, as they use a different calibration command as stated here : https://github.com/adafruit/Adafruit_CircuitPython_AHTx0/issues/17#issue-1920433739

To fix this problem the version should be bumped to the current one where they try the old and new calibration command. So far no other problems occured with this bugfix.