### PR TITLE
Add global random seed for deterministic tests

### DIFF
--- a/mycodo/tests/software_tests/test_mycodo_flask/test_endpoints.py
+++ b/mycodo/tests/software_tests/test_mycodo_flask/test_endpoints.py
@@ -23,6 +23,7 @@ from mycodo.utils.outputs import parse_output_information
 from mycodo.utils.utils import random_alphanumeric
 from mycodo.utils.widgets import parse_widget_information
 
+random.seed(42) # for reproducibility
 
 # ----------------------
 #   Non-Logged In Tests


### PR DESCRIPTION
### Description

This PR introduces a global random seed set after imports in the test file. This change aims to make the tests more deterministic and easier to debug by ensuring consistent random behavior across test runs.

### Current Issues (Before this PR):

The tests currently use random without setting a fixed seed, which causes several problems :

a. Flaky Tests: Tests sometimes pass and sometimes fail due to different random values;
b. Hard to Reproduce: When a test fails, it's difficult to reproduce the exact conditions;
c. Inconsistent CI/CD: Different CI runs may have different outcomes;
d. Time Wasted: Developers spend time debugging issues that are hard to replicate.

(Im not saying these problems are happening, but they can happen.)

### Solution

Set a global random seed right after imports in the test file.

### Benefits

a. Reproducibility: All test runs will use the same random values;
b. Easier Debugging: When a test fails, we can easily reproduce the issue;
c. Consistent CI/CD: Every CI run will have the same behavior;
d. Clear Intent: It's immediately obvious that we're using controlled randomness;
e. Time Saved: Less time spent on debugging non-deterministic test failures.