### PR TITLE
Guard Ramp‑PWM against division‑by‑zero (start==end or increment==0)

### DIFF
--- a/mycodo/actions/output_ramp_pwm.py
+++ b/mycodo/actions/output_ramp_pwm.py
@@ -150,7 +150,10 @@ class ActionModule(AbstractFunctionAction):
                                 f"of {increment} over {duration} seconds."
 
         change_in_duty_cycle = abs(start - end)
-        steps = change_in_duty_cycle * 1 / increment
+        steps = change_in_duty_cycle / increment if increment else 0
+        if steps == 0:
+            self.logger.warning("Ramp‑PWM: start==end or increment==0 – skipping ramp")
+            return dict_vars
         seconds_per_step = duration / steps
 
         current_duty_cycle = start


### PR DESCRIPTION
#### Problem
`output_ramp_pwm` could attempt to divide by zero, crashing the action thread and leaving the output in an unexpected state.

#### Cause
`steps` was computed as `abs(start‑end)/increment` without validating that it was non‑zero.

#### Solution
* Derive `steps` safely and bail out if the ramp would be a NOP.
* Log a concise warning so users know why the ramp was skipped.

No other functional changes.
