### PR TITLE
Fix OpenWeather One Call API endpoint to use v3.0 for clearer error messaging

### DIFF
--- a/mycodo/inputs/weather_openweathermap_onecall.py
+++ b/mycodo/inputs/weather_openweathermap_onecall.py
@@ -190,7 +190,7 @@ class InputModule(AbstractInput):
 
     def initialize(self):
         if self.api_key and self.latitude and self.longitude and self.weather_time:
-            base_url = "https://api.openweathermap.org/data/2.5/onecall?lat={lat}&lon={lon}&units=metric&appid={key}".format(
+            base_url = "https://api.openweathermap.org/data/3.0/onecall?lat={lat}&lon={lon}&units=metric&appid={key}".format(
                 lat=self.latitude, lon=self.longitude, key=self.api_key)
             if self.weather_time == 'current':
                 self.weather_time_dict["time"] = "current"


### PR DESCRIPTION
### Summary
This PR updates the OpenWeather One Call API endpoint from version 2.5 to 3.0.

### Why
The v2.5 endpoint returns a misleading error message when an API key lacks access to the One Call service:
> "Invalid API key. Please see https://openweathermap.org/faq#error401 for more info."

This is confusing for users, as the real issue is that access to One Call requires a **paid subscription** to the “One Call by Call” plan.

Using the v3.0 endpoint resolves this by providing the correct and much more informative message:
> "Please note that using One Call 3.0 requires a separate subscription to the One Call by Call plan. Learn more here https://openweathermap.org/price..."

### Impact
- Better user experience and faster troubleshooting.
- Prevents unnecessary debugging when the actual issue is subscription-related.

No additional logic changes were made beyond updating the endpoint URL.
