### PR TITLE
fix(devices): add missing build_string method to Atlas Scientific UART

### DIFF
--- a/mycodo/devices/atlas_scientific_uart.py
+++ b/mycodo/devices/atlas_scientific_uart.py
@@ -135,6 +135,24 @@ class AtlasScientificUART(AbstractBaseAtlasScientific):
             self.logger.exception('UART device not initialized')
             return None
 
+    @staticmethod
+    def build_string(data):
+        """
+        Build a string from data, filtering out non-alphanumeric characters
+        except for '.' and ','. Used during calibration.
+        """
+        try:
+            list_chars = []
+            for each_char in data:
+                try:
+                    if each_char.isalnum() or each_char in [".", ","]:
+                        list_chars.append(each_char)
+                except:
+                    pass
+            return ''.join(list_chars)
+        except:
+            return None
+
 
 def main():
     device_str = input("Device? (e.g. '/dev/ttyAMA1'): ")


### PR DESCRIPTION
## Description

Fixes #1395 - Add missing `build_string()` method to Atlas Scientific UART class.

## Problem

When using Atlas Scientific sensors (pH, EC, DO, ORP, etc.) via UART interface, calibration fails with an `AttributeError` because the `build_string()` method exists only in the I2C class but not in the UART class.

All Atlas Scientific inputs call `self.atlas_device.build_string()` during calibration, which works for I2C but fails for UART users.

## Solution

Added the `build_string()` static method to `AtlasScientificUART` class, copied from the I2C implementation. The method filters data to only include alphanumeric characters plus `.` and `,`.

## Changes

- Added `build_string()` static method to `mycodo/devices/atlas_scientific_uart.py`

## Testing

- Code review: method is identical to the working I2C version
- No hardware available for testing, but the fix is straightforward