### PR TITLE
Fix function average_past_single dropping average of zero

### DIFF
--- a/mycodo/functions/average_past_single.py
+++ b/mycodo/functions/average_past_single.py
@@ -156,7 +156,7 @@ class CustomModule(AbstractFunction):
             self.max_measure_age,
             measure=measurement)
 
-        if not average:
+        if average is None:
             self.logger.error("Could not find measurement within the set Max Age")
             return False
 


### PR DESCRIPTION
Function average_past_single mistakes an average of zero as there being no data to calculate an average from, so it was dropping the result.

This PR makes it check for `None` (the response given when there's no data) rather than checking for anything false-like, so averages of zero can go through.