### PR TITLE
Fix InfluxDB 1.x mean/sum and grouped query double-aggregation

### DIFF
--- a/mycodo/tests/software_tests/test_influxdb/test_manual_aggregation.py
+++ b/mycodo/tests/software_tests/test_influxdb/test_manual_aggregation.py
@@ -2,8 +2,7 @@
 """Unit tests for InfluxDB 1.x manual aggregation helpers.
 
 These tests use synthetic table/record objects (no live InfluxDB required)
-to verify window alignment, timestamp selection, and correctness for
-_manual_aggregate_mean, _manual_calculate_mean, and _manual_calculate_sum.
+to verify correctness for _manual_calculate_mean and _manual_calculate_sum.
 """
 import datetime
 
@@ -12,7 +11,6 @@ import pytest
 from mycodo.utils.influx import (
     _ManualRecord,
     _ManualTable,
-    _manual_aggregate_mean,
     _manual_calculate_mean,
     _manual_calculate_sum,
 )
@@ -120,134 +118,17 @@ class TestManualCalculateSum:
 
 
 # ---------------------------------------------------------------------------
-# _manual_aggregate_mean
+# Integration: value combinations return a single scalar
 # ---------------------------------------------------------------------------
 
-class TestManualAggregateMean:
+class TestManualCalculateScalars:
     """
-    Windows are epoch-aligned: aligned_start = floor(epoch / group_sec) * group_sec
-    The aggregated record's timestamp is the window *end*: aligned_start + group_sec.
-    """
-
-    GROUP_SEC = 60  # 1-minute windows
-
-    def _epoch_to_dt(self, epoch):
-        return datetime.datetime.fromtimestamp(epoch, tz=UTC)
-
-    def test_empty_input_returns_empty_list(self):
-        assert _manual_aggregate_mean([], self.GROUP_SEC) == []
-
-    def test_empty_table_returns_empty_list(self):
-        tables = [_ManualTable([])]
-        assert _manual_aggregate_mean(tables, self.GROUP_SEC) == []
-
-    def test_all_none_values_returns_empty_list(self):
-        ts = self._epoch_to_dt(1000)
-        tables = _make_tables([(ts, None)])
-        assert _manual_aggregate_mean(tables, self.GROUP_SEC) == []
-
-    def test_single_point_in_one_window(self):
-        # epoch=1000 → aligned_start=floor(1000/60)*60=960 → window_end=1020
-        epoch = 1000
-        ts = self._epoch_to_dt(epoch)
-        tables = _make_tables([(ts, 7.5)])
-        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
-        assert len(result) == 1
-        assert len(result[0].records) == 1
-        record = result[0].records[0]
-        assert record.values['_value'] == pytest.approx(7.5)
-        expected_window_end = datetime.datetime.fromtimestamp(960 + 60, tz=UTC)
-        assert record.values['_time'] == expected_window_end
-
-    def test_multiple_points_in_same_window_mean(self):
-        # epochs 1000 and 1010 both fall in window [960, 1020)
-        ts1 = self._epoch_to_dt(1000)
-        ts2 = self._epoch_to_dt(1010)
-        tables = _make_tables([(ts1, 10.0), (ts2, 20.0)])
-        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
-        assert len(result) == 1
-        record = result[0].records[0]
-        assert record.values['_value'] == pytest.approx(15.0)  # (10+20)/2
-        expected_window_end = datetime.datetime.fromtimestamp(960 + 60, tz=UTC)
-        assert record.values['_time'] == expected_window_end
-
-    def test_points_in_multiple_windows(self):
-        # epoch 1000 → window [960, 1020), window_end=1020
-        # epoch 1080 → window [1080, 1140), window_end=1140
-        ts1 = self._epoch_to_dt(1000)
-        ts2 = self._epoch_to_dt(1010)
-        ts3 = self._epoch_to_dt(1080)
-        ts4 = self._epoch_to_dt(1090)
-        tables = _make_tables([(ts1, 10.0), (ts2, 30.0), (ts3, 5.0), (ts4, 15.0)])
-        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
-        assert len(result) == 1
-        assert len(result[0].records) == 2
-
-        rec0 = result[0].records[0]
-        assert rec0.values['_value'] == pytest.approx(20.0)  # (10+30)/2
-        assert rec0.values['_time'] == datetime.datetime.fromtimestamp(1020, tz=UTC)
-
-        rec1 = result[0].records[1]
-        assert rec1.values['_value'] == pytest.approx(10.0)  # (5+15)/2
-        assert rec1.values['_time'] == datetime.datetime.fromtimestamp(1140, tz=UTC)
-
-    def test_epoch_aligned_boundary_point_starts_new_window(self):
-        # A point exactly on a window boundary (epoch=1020) starts the NEXT window [1020, 1080)
-        ts_before = self._epoch_to_dt(1019)  # window [960, 1020)
-        ts_on = self._epoch_to_dt(1020)      # window [1020, 1080)
-        tables = _make_tables([(ts_before, 3.0), (ts_on, 9.0)])
-        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
-        assert len(result[0].records) == 2
-
-        rec0 = result[0].records[0]
-        assert rec0.values['_value'] == pytest.approx(3.0)
-        assert rec0.values['_time'] == datetime.datetime.fromtimestamp(1020, tz=UTC)
-
-        rec1 = result[0].records[1]
-        assert rec1.values['_value'] == pytest.approx(9.0)
-        assert rec1.values['_time'] == datetime.datetime.fromtimestamp(1080, tz=UTC)
-
-    def test_skips_none_values(self):
-        ts1 = self._epoch_to_dt(1000)
-        ts2 = self._epoch_to_dt(1010)
-        tables = _make_tables([(ts1, None), (ts2, 20.0)])
-        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
-        assert len(result[0].records) == 1
-        assert result[0].records[0].values['_value'] == pytest.approx(20.0)
-
-    def test_timezone_preserved_in_result(self):
-        """Window-end timestamps should carry the same timezone as the input."""
-        epoch = 1000
-        ts = self._epoch_to_dt(epoch)
-        assert ts.tzinfo is not None
-        tables = _make_tables([(ts, 1.0)])
-        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
-        result_time = result[0].records[0].values['_time']
-        assert result_time.tzinfo == UTC
-
-    def test_results_sorted_by_window(self):
-        """Even with unsorted input, output windows are in ascending order."""
-        ts_late = self._epoch_to_dt(1090)
-        ts_early = self._epoch_to_dt(1000)
-        tables = _make_tables([(ts_late, 99.0), (ts_early, 1.0)])
-        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
-        times = [r.values['_time'] for r in result[0].records]
-        assert times == sorted(times)
-
-
-# ---------------------------------------------------------------------------
-# Integration: value + group_sec combinations should NOT use _manual_aggregate_mean
-# ---------------------------------------------------------------------------
-
-class TestManualAggregateMeanNotCalledWithExplicitValue:
-    """
-    Verify that _manual_calculate_mean and _manual_calculate_sum return a single
-    scalar result (not per-window), which is the correct behaviour when value=
-    "MEAN"/"SUM" is combined with group_sec — the manual aggregate should not
-    override the explicit aggregation.
+    Verify that _manual_calculate_mean and _manual_calculate_sum each return a
+    single scalar record regardless of how the input points are distributed over
+    time — the per-window manual aggregation path is handled server-side.
     """
 
-    def test_mean_returns_single_value_not_per_window(self):
+    def test_mean_returns_single_value(self):
         # Three points spread across two 60-second windows
         ts1 = datetime.datetime.fromtimestamp(1000, tz=UTC)
         ts2 = datetime.datetime.fromtimestamp(1010, tz=UTC)
@@ -258,7 +139,7 @@ class TestManualAggregateMeanNotCalledWithExplicitValue:
         assert len(result[0].records) == 1
         assert result[0].records[0].values['_value'] == pytest.approx(20.0)
 
-    def test_sum_returns_single_value_not_per_window(self):
+    def test_sum_returns_single_value(self):
         ts1 = datetime.datetime.fromtimestamp(1000, tz=UTC)
         ts2 = datetime.datetime.fromtimestamp(1010, tz=UTC)
         ts3 = datetime.datetime.fromtimestamp(1080, tz=UTC)

--- a/mycodo/tests/software_tests/test_influxdb/test_manual_aggregation.py
+++ b/mycodo/tests/software_tests/test_influxdb/test_manual_aggregation.py
@@ -1,0 +1,285 @@
+# coding=utf-8
+"""Unit tests for InfluxDB 1.x manual aggregation helpers.
+
+These tests use synthetic table/record objects (no live InfluxDB required)
+to verify window alignment, timestamp selection, and correctness for
+_manual_aggregate_mean, _manual_calculate_mean, and _manual_calculate_sum.
+"""
+import datetime
+import sys
+from unittest.mock import MagicMock
+
+# Stub out heavy dependencies so that mycodo.utils.influx can be imported
+# without a live database or Flask application context.
+for _mod in (
+    'mycodo.databases',
+    'mycodo.databases.models',
+    'mycodo.mycodo_client',
+    'mycodo.utils.database',
+    'mycodo.utils.system_pi',
+    'requests',
+    'influxdb_client',
+    'influxdb_client.client',
+    'influxdb_client.client.write_api',
+):
+    sys.modules.setdefault(_mod, MagicMock())
+
+import pytest
+
+from mycodo.utils.influx import (
+    _ManualRecord,
+    _ManualTable,
+    _manual_aggregate_mean,
+    _manual_calculate_mean,
+    _manual_calculate_sum,
+)
+
+UTC = datetime.timezone.utc
+
+
+def _make_tables(points):
+    """Build a list of one _ManualTable from (datetime, value) pairs."""
+    records = [_ManualRecord(ts, val) for ts, val in points]
+    return [_ManualTable(records)]
+
+
+# ---------------------------------------------------------------------------
+# _manual_calculate_mean
+# ---------------------------------------------------------------------------
+
+class TestManualCalculateMean:
+    def test_empty_input_returns_empty_list(self):
+        assert _manual_calculate_mean([]) == []
+
+    def test_empty_table_returns_empty_list(self):
+        tables = [_ManualTable([])]
+        assert _manual_calculate_mean(tables) == []
+
+    def test_all_none_values_returns_empty_list(self):
+        tables = _make_tables([(datetime.datetime(2024, 1, 1, tzinfo=UTC), None)])
+        assert _manual_calculate_mean(tables) == []
+
+    def test_single_point(self):
+        ts = datetime.datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        tables = _make_tables([(ts, 42.0)])
+        result = _manual_calculate_mean(tables)
+        assert len(result) == 1
+        assert len(result[0].records) == 1
+        record = result[0].records[0]
+        assert record.values['_value'] == pytest.approx(42.0)
+        assert record.values['_time'] == ts
+
+    def test_multiple_points_correct_mean(self):
+        ts1 = datetime.datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        ts2 = datetime.datetime(2024, 1, 1, 0, 1, 0, tzinfo=UTC)
+        ts3 = datetime.datetime(2024, 1, 1, 0, 2, 0, tzinfo=UTC)
+        tables = _make_tables([(ts1, 10.0), (ts2, 20.0), (ts3, 30.0)])
+        result = _manual_calculate_mean(tables)
+        assert len(result) == 1
+        record = result[0].records[0]
+        assert record.values['_value'] == pytest.approx(20.0)  # (10+20+30)/3
+        assert record.values['_time'] == ts3  # uses last timestamp
+
+    def test_skips_none_values(self):
+        ts1 = datetime.datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        ts2 = datetime.datetime(2024, 1, 1, 0, 1, 0, tzinfo=UTC)
+        ts3 = datetime.datetime(2024, 1, 1, 0, 2, 0, tzinfo=UTC)
+        tables = _make_tables([(ts1, 10.0), (ts2, None), (ts3, 30.0)])
+        result = _manual_calculate_mean(tables)
+        record = result[0].records[0]
+        assert record.values['_value'] == pytest.approx(20.0)  # (10+30)/2
+
+
+# ---------------------------------------------------------------------------
+# _manual_calculate_sum
+# ---------------------------------------------------------------------------
+
+class TestManualCalculateSum:
+    def test_empty_input_returns_empty_list(self):
+        assert _manual_calculate_sum([]) == []
+
+    def test_empty_table_returns_empty_list(self):
+        tables = [_ManualTable([])]
+        assert _manual_calculate_sum(tables) == []
+
+    def test_all_none_values_returns_empty_list(self):
+        tables = _make_tables([(datetime.datetime(2024, 1, 1, tzinfo=UTC), None)])
+        assert _manual_calculate_sum(tables) == []
+
+    def test_single_point(self):
+        ts = datetime.datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        tables = _make_tables([(ts, 5.0)])
+        result = _manual_calculate_sum(tables)
+        assert len(result) == 1
+        record = result[0].records[0]
+        assert record.values['_value'] == pytest.approx(5.0)
+        assert record.values['_time'] == ts
+
+    def test_multiple_points_correct_sum(self):
+        ts1 = datetime.datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        ts2 = datetime.datetime(2024, 1, 1, 0, 1, 0, tzinfo=UTC)
+        ts3 = datetime.datetime(2024, 1, 1, 0, 2, 0, tzinfo=UTC)
+        tables = _make_tables([(ts1, 10.0), (ts2, 20.0), (ts3, 30.0)])
+        result = _manual_calculate_sum(tables)
+        assert len(result) == 1
+        record = result[0].records[0]
+        assert record.values['_value'] == pytest.approx(60.0)
+        assert record.values['_time'] == ts3  # uses last timestamp
+
+    def test_skips_none_values(self):
+        ts1 = datetime.datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        ts2 = datetime.datetime(2024, 1, 1, 0, 1, 0, tzinfo=UTC)
+        ts3 = datetime.datetime(2024, 1, 1, 0, 2, 0, tzinfo=UTC)
+        tables = _make_tables([(ts1, 10.0), (ts2, None), (ts3, 30.0)])
+        result = _manual_calculate_sum(tables)
+        record = result[0].records[0]
+        assert record.values['_value'] == pytest.approx(40.0)
+
+
+# ---------------------------------------------------------------------------
+# _manual_aggregate_mean
+# ---------------------------------------------------------------------------
+
+class TestManualAggregateMean:
+    """
+    Windows are epoch-aligned: aligned_start = floor(epoch / group_sec) * group_sec
+    The aggregated record's timestamp is the window *end*: aligned_start + group_sec.
+    """
+
+    GROUP_SEC = 60  # 1-minute windows
+
+    def _epoch_to_dt(self, epoch):
+        return datetime.datetime.fromtimestamp(epoch, tz=UTC)
+
+    def test_empty_input_returns_empty_list(self):
+        assert _manual_aggregate_mean([], self.GROUP_SEC) == []
+
+    def test_empty_table_returns_empty_list(self):
+        tables = [_ManualTable([])]
+        assert _manual_aggregate_mean(tables, self.GROUP_SEC) == []
+
+    def test_all_none_values_returns_empty_list(self):
+        ts = self._epoch_to_dt(1000)
+        tables = _make_tables([(ts, None)])
+        assert _manual_aggregate_mean(tables, self.GROUP_SEC) == []
+
+    def test_single_point_in_one_window(self):
+        # epoch=1000 → aligned_start=floor(1000/60)*60=960 → window_end=1020
+        epoch = 1000
+        ts = self._epoch_to_dt(epoch)
+        tables = _make_tables([(ts, 7.5)])
+        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
+        assert len(result) == 1
+        assert len(result[0].records) == 1
+        record = result[0].records[0]
+        assert record.values['_value'] == pytest.approx(7.5)
+        expected_window_end = datetime.datetime.fromtimestamp(960 + 60, tz=UTC)
+        assert record.values['_time'] == expected_window_end
+
+    def test_multiple_points_in_same_window_mean(self):
+        # epochs 1000 and 1010 both fall in window [960, 1020)
+        ts1 = self._epoch_to_dt(1000)
+        ts2 = self._epoch_to_dt(1010)
+        tables = _make_tables([(ts1, 10.0), (ts2, 20.0)])
+        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
+        assert len(result) == 1
+        record = result[0].records[0]
+        assert record.values['_value'] == pytest.approx(15.0)  # (10+20)/2
+        expected_window_end = datetime.datetime.fromtimestamp(960 + 60, tz=UTC)
+        assert record.values['_time'] == expected_window_end
+
+    def test_points_in_multiple_windows(self):
+        # epoch 1000 → window [960, 1020), window_end=1020
+        # epoch 1080 → window [1080, 1140), window_end=1140
+        ts1 = self._epoch_to_dt(1000)
+        ts2 = self._epoch_to_dt(1010)
+        ts3 = self._epoch_to_dt(1080)
+        ts4 = self._epoch_to_dt(1090)
+        tables = _make_tables([(ts1, 10.0), (ts2, 30.0), (ts3, 5.0), (ts4, 15.0)])
+        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
+        assert len(result) == 1
+        assert len(result[0].records) == 2
+
+        rec0 = result[0].records[0]
+        assert rec0.values['_value'] == pytest.approx(20.0)  # (10+30)/2
+        assert rec0.values['_time'] == datetime.datetime.fromtimestamp(1020, tz=UTC)
+
+        rec1 = result[0].records[1]
+        assert rec1.values['_value'] == pytest.approx(10.0)  # (5+15)/2
+        assert rec1.values['_time'] == datetime.datetime.fromtimestamp(1140, tz=UTC)
+
+    def test_epoch_aligned_boundary_point_starts_new_window(self):
+        # A point exactly on a window boundary (epoch=1020) starts the NEXT window [1020, 1080)
+        ts_before = self._epoch_to_dt(1019)  # window [960, 1020)
+        ts_on = self._epoch_to_dt(1020)      # window [1020, 1080)
+        tables = _make_tables([(ts_before, 3.0), (ts_on, 9.0)])
+        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
+        assert len(result[0].records) == 2
+
+        rec0 = result[0].records[0]
+        assert rec0.values['_value'] == pytest.approx(3.0)
+        assert rec0.values['_time'] == datetime.datetime.fromtimestamp(1020, tz=UTC)
+
+        rec1 = result[0].records[1]
+        assert rec1.values['_value'] == pytest.approx(9.0)
+        assert rec1.values['_time'] == datetime.datetime.fromtimestamp(1080, tz=UTC)
+
+    def test_skips_none_values(self):
+        ts1 = self._epoch_to_dt(1000)
+        ts2 = self._epoch_to_dt(1010)
+        tables = _make_tables([(ts1, None), (ts2, 20.0)])
+        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
+        assert len(result[0].records) == 1
+        assert result[0].records[0].values['_value'] == pytest.approx(20.0)
+
+    def test_timezone_preserved_in_result(self):
+        """Window-end timestamps should carry the same timezone as the input."""
+        epoch = 1000
+        ts = self._epoch_to_dt(epoch)
+        assert ts.tzinfo is not None
+        tables = _make_tables([(ts, 1.0)])
+        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
+        result_time = result[0].records[0].values['_time']
+        assert result_time.tzinfo == UTC
+
+    def test_results_sorted_by_window(self):
+        """Even with unsorted input, output windows are in ascending order."""
+        ts_late = self._epoch_to_dt(1090)
+        ts_early = self._epoch_to_dt(1000)
+        tables = _make_tables([(ts_late, 99.0), (ts_early, 1.0)])
+        result = _manual_aggregate_mean(tables, self.GROUP_SEC)
+        times = [r.values['_time'] for r in result[0].records]
+        assert times == sorted(times)
+
+
+# ---------------------------------------------------------------------------
+# Integration: value + group_sec combinations should NOT use _manual_aggregate_mean
+# ---------------------------------------------------------------------------
+
+class TestManualAggregateMeanNotCalledWithExplicitValue:
+    """
+    Verify that _manual_calculate_mean and _manual_calculate_sum return a single
+    scalar result (not per-window), which is the correct behaviour when value=
+    "MEAN"/"SUM" is combined with group_sec — the manual aggregate should not
+    override the explicit aggregation.
+    """
+
+    def test_mean_returns_single_value_not_per_window(self):
+        # Three points spread across two 60-second windows
+        ts1 = datetime.datetime.fromtimestamp(1000, tz=UTC)
+        ts2 = datetime.datetime.fromtimestamp(1010, tz=UTC)
+        ts3 = datetime.datetime.fromtimestamp(1080, tz=UTC)
+        tables = _make_tables([(ts1, 10.0), (ts2, 20.0), (ts3, 30.0)])
+        result = _manual_calculate_mean(tables)
+        # Should be ONE record with overall mean, not two windowed means
+        assert len(result[0].records) == 1
+        assert result[0].records[0].values['_value'] == pytest.approx(20.0)
+
+    def test_sum_returns_single_value_not_per_window(self):
+        ts1 = datetime.datetime.fromtimestamp(1000, tz=UTC)
+        ts2 = datetime.datetime.fromtimestamp(1010, tz=UTC)
+        ts3 = datetime.datetime.fromtimestamp(1080, tz=UTC)
+        tables = _make_tables([(ts1, 10.0), (ts2, 20.0), (ts3, 30.0)])
+        result = _manual_calculate_sum(tables)
+        assert len(result[0].records) == 1
+        assert result[0].records[0].values['_value'] == pytest.approx(60.0)

--- a/mycodo/tests/software_tests/test_influxdb/test_manual_aggregation.py
+++ b/mycodo/tests/software_tests/test_influxdb/test_manual_aggregation.py
@@ -6,23 +6,6 @@ to verify window alignment, timestamp selection, and correctness for
 _manual_aggregate_mean, _manual_calculate_mean, and _manual_calculate_sum.
 """
 import datetime
-import sys
-from unittest.mock import MagicMock
-
-# Stub out heavy dependencies so that mycodo.utils.influx can be imported
-# without a live database or Flask application context.
-for _mod in (
-    'mycodo.databases',
-    'mycodo.databases.models',
-    'mycodo.mycodo_client',
-    'mycodo.utils.database',
-    'mycodo.utils.system_pi',
-    'requests',
-    'influxdb_client',
-    'influxdb_client.client',
-    'influxdb_client.client.write_api',
-):
-    sys.modules.setdefault(_mod, MagicMock())
 
 import pytest
 

--- a/mycodo/utils/influx.py
+++ b/mycodo/utils/influx.py
@@ -301,11 +301,7 @@ def query_flux(unit, unique_id,
 
     # Manual calculation for InfluxDB 1.x
     if settings.measurement_db_version == '1':
-        if group_sec and not value and not server_side_windowed:
-            # group_sec was requested with no explicit aggregation and server-side
-            # windowing was not applied, so perform manual mean aggregation.
-            tables = _manual_aggregate_mean(tables, group_sec)
-        elif value == "MEAN":
+        if value == "MEAN":
             tables = _manual_calculate_mean(tables)
         elif value == "SUM":
             tables = _manual_calculate_sum(tables)
@@ -630,7 +626,7 @@ def influxdb_get_first_point(data):
     for table in data:
         for record in table.records:
             return record.values['_time']
-        
+
 
 class _ManualRecord:
     """Mimics InfluxDB record structure for manual aggregation results."""
@@ -642,61 +638,6 @@ class _ManualTable:
     """Mimics InfluxDB table structure for manual aggregation results."""
     def __init__(self, records):
         self.records = records
-
-
-def _manual_aggregate_mean(tables, group_sec):
-    """
-    Manually aggregate data into time groups and calculate mean for each group.
-    Used as workaround for InfluxDB 1.8.10 Flux bug with mean/aggregateWindow.
-    Windows are epoch-aligned (floor(epoch/group_sec)*group_sec) and the
-    aggregated point time is the window end, matching Flux aggregateWindow defaults.
-    """
-    # Extract all measurements with their epoch representation
-    measurements = []
-    for table in tables:
-        for row in table.records:
-            timestamp = row.values['_time']
-            value = row.values['_value']
-            if value is not None:
-                if hasattr(timestamp, 'timestamp'):
-                    epoch = timestamp.timestamp()
-                else:
-                    epoch = float(timestamp)
-                measurements.append((timestamp, epoch, value))
-
-    if not measurements:
-        return []
-
-    # Sort by epoch time
-    measurements.sort(key=lambda x: x[1])
-
-    # Aggregate into epoch-aligned time windows and calculate means.
-    # Windows are aligned to fixed boundaries: [n*group_sec, (n+1)*group_sec)
-    grouped = {}
-    for ts, epoch, value in measurements:
-        aligned_start = (epoch // group_sec) * group_sec
-        if aligned_start not in grouped:
-            grouped[aligned_start] = []
-        grouped[aligned_start].append((ts, value))
-
-    aggregated = []
-    sample_ts = measurements[0][0]
-    tz = getattr(sample_ts, 'tzinfo', None)
-    for aligned_start in sorted(grouped.keys()):
-        group_points = grouped[aligned_start]
-        mean_val = sum(v for _, v in group_points) / len(group_points)
-
-        # Use window end as the timestamp, matching Flux aggregateWindow default behavior.
-        window_end_epoch = aligned_start + group_sec
-        if hasattr(sample_ts, 'timestamp'):
-            group_time = datetime.datetime.fromtimestamp(window_end_epoch, tz)
-        else:
-            group_time = window_end_epoch
-
-        aggregated.append(_ManualRecord(group_time, mean_val))
-
-    return [_ManualTable(aggregated)]
-
 
 
 def _manual_calculate_mean(tables):

--- a/mycodo/utils/influx.py
+++ b/mycodo/utils/influx.py
@@ -234,6 +234,7 @@ def query_flux(unit, unique_id,
     if ts_str:
         query += " AND time = '{ts}'".format(ts=ts_str)
 
+    server_side_windowed = False
     if group_sec:
         # Bug in influxdb/Flux v1.8.10 due to mean, but 1.x is EOL so won't be fixed
         # Original workaround was to query all measurements, then simulate aggregateWindow with mean for 1.x
@@ -257,6 +258,7 @@ def query_flux(unit, unique_id,
                 ')'
                 ' |> map(fn: (r) => ({ _time: r._stop, _value: r.sum / float(v: r.count) }))'
             )
+            server_side_windowed = True
     if limit:
         query += f' |> limit(n:{limit})'
 
@@ -299,7 +301,9 @@ def query_flux(unit, unique_id,
 
     # Manual calculation for InfluxDB 1.x
     if settings.measurement_db_version == '1':
-        if group_sec:
+        if group_sec and not server_side_windowed:
+            # Server-side windowing was not applied (e.g., value was specified with group_sec),
+            # so perform manual mean aggregation over the grouped windows.
             tables = _manual_aggregate_mean(tables, group_sec)
         elif value == "MEAN":
             tables = _manual_calculate_mean(tables)

--- a/mycodo/utils/influx.py
+++ b/mycodo/utils/influx.py
@@ -648,60 +648,52 @@ def _manual_aggregate_mean(tables, group_sec):
     """
     Manually aggregate data into time groups and calculate mean for each group.
     Used as workaround for InfluxDB 1.8.10 Flux bug with mean/aggregateWindow.
+    Windows are epoch-aligned (floor(epoch/group_sec)*group_sec) and the
+    aggregated point time is the window end, matching Flux aggregateWindow defaults.
     """
-    # First, extract all measurements
+    # Extract all measurements with their epoch representation
     measurements = []
     for table in tables:
         for row in table.records:
             timestamp = row.values['_time']
             value = row.values['_value']
             if value is not None:
-                measurements.append((timestamp, value))
+                if hasattr(timestamp, 'timestamp'):
+                    epoch = timestamp.timestamp()
+                else:
+                    epoch = float(timestamp)
+                measurements.append((timestamp, epoch, value))
 
     if not measurements:
         return []
 
-    # Sort by timestamp
-    measurements.sort(key=lambda x: x[0].timestamp() if hasattr(x[0], 'timestamp') else float(x[0]))
+    # Sort by epoch time
+    measurements.sort(key=lambda x: x[1])
 
-    # Aggregate into time groups and calculate means
+    # Aggregate into epoch-aligned time windows and calculate means.
+    # Windows are aligned to fixed boundaries: [n*group_sec, (n+1)*group_sec)
+    grouped = {}
+    for ts, epoch, value in measurements:
+        aligned_start = (epoch // group_sec) * group_sec
+        if aligned_start not in grouped:
+            grouped[aligned_start] = []
+        grouped[aligned_start].append((ts, value))
+
     aggregated = []
-    if measurements:
-        first_ts = measurements[0][0]
-        if hasattr(first_ts, 'timestamp'):
-            start_epoch = first_ts.timestamp()
+    sample_ts = measurements[0][0]
+    tz = getattr(sample_ts, 'tzinfo', None)
+    for aligned_start in sorted(grouped.keys()):
+        group_points = grouped[aligned_start]
+        mean_val = sum(v for _, v in group_points) / len(group_points)
+
+        # Use window end as the timestamp, matching Flux aggregateWindow default behavior.
+        window_end_epoch = aligned_start + group_sec
+        if hasattr(sample_ts, 'timestamp'):
+            group_time = datetime.datetime.fromtimestamp(window_end_epoch, tz)
         else:
-            start_epoch = first_ts
+            group_time = window_end_epoch
 
-        current_group_start = start_epoch
-        current_group_values = []
-
-        for ts, value in measurements:
-            if hasattr(ts, 'timestamp'):
-                epoch = ts.timestamp()
-            else:
-                epoch = ts
-
-            # Check if this measurement belongs to current group
-            if epoch < current_group_start + group_sec:
-                current_group_values.append((ts, value))
-            else:
-                # Finalize current group
-                if current_group_values:
-                    mean_val = sum(v for _, v in current_group_values) / len(current_group_values)
-                    group_time = current_group_values[0][0]  # Use first timestamp in group
-                    aggregated.append(_ManualRecord(group_time, mean_val))
-
-                # Start new group (advance to the group containing this point)
-                while epoch >= current_group_start + group_sec:
-                    current_group_start += group_sec
-                current_group_values = [(ts, value)]
-
-        # Don't forget the last group
-        if current_group_values:
-            mean_val = sum(v for _, v in current_group_values) / len(current_group_values)
-            group_time = current_group_values[0][0]
-            aggregated.append(_ManualRecord(group_time, mean_val))
+        aggregated.append(_ManualRecord(group_time, mean_val))
 
     return [_ManualTable(aggregated)]
 

--- a/mycodo/utils/influx.py
+++ b/mycodo/utils/influx.py
@@ -236,13 +236,27 @@ def query_flux(unit, unique_id,
 
     if group_sec:
         # Bug in influxdb/Flux v1.8.10 due to mean, but 1.x is EOL so won't be fixed
-        # Workaround is to query all measurements, then simulate aggregateWindow with mean for 1.x 
+        # Original workaround was to query all measurements, then simulate aggregateWindow with mean for 1.x
         # Error: panic: runtime error: invalid memory address or nil pointer dereference
         # https://github.com/influxdata/influxdb/issues/21649
         # https://github.com/influxdata/influxdb/pull/23520
         if settings.measurement_db_version == '2':
+            # Safe to use aggregateWindow with mean on InfluxDB 2.x
             query += f' |> aggregateWindow(every: {group_sec}s, fn: mean)'
-
+        elif settings.measurement_db_version == '1' and not value:
+            # For InfluxDB 1.x, avoid aggregateWindow(mean) and perform windowing via window() + reduce().
+            # This computes a per-window mean server-side to avoid transferring all raw points.
+            query += (
+                f' |> window(every: {group_sec}s)'
+                ' |> reduce('
+                'identity: {sum: 0.0, count: 0}, '
+                'fn: (r, accumulator) => ({'
+                'sum: accumulator.sum + r._value, '
+                'count: accumulator.count + 1'
+                '})'
+                ')'
+                ' |> map(fn: (r) => ({ _time: r._stop, _value: r.sum / float(v: r.count) }))'
+            )
     if limit:
         query += f' |> limit(n:{limit})'
 

--- a/mycodo/utils/influx.py
+++ b/mycodo/utils/influx.py
@@ -301,9 +301,9 @@ def query_flux(unit, unique_id,
 
     # Manual calculation for InfluxDB 1.x
     if settings.measurement_db_version == '1':
-        if group_sec and not server_side_windowed:
-            # Server-side windowing was not applied (e.g., value was specified with group_sec),
-            # so perform manual mean aggregation over the grouped windows.
+        if group_sec and not value and not server_side_windowed:
+            # group_sec was requested with no explicit aggregation and server-side
+            # windowing was not applied, so perform manual mean aggregation.
             tables = _manual_aggregate_mean(tables, group_sec)
         elif value == "MEAN":
             tables = _manual_calculate_mean(tables)


### PR DESCRIPTION
Fixes InfluxDB 1.8.x crash bug when using MEAN or SUM in Flux queries. Previously, Mycodo worked around this by substituting MEDIAN for MEAN. Now, for InfluxDB 1.x, querying MEAN returns the actual mean and SUM returns the actual sum.

## Changes Made

- **MEAN/SUM on InfluxDB 1.x**: Removed the `|> median()` workaround for MEAN and the raw-point summing workaround for SUM. Raw points are now fetched and `_manual_calculate_mean()` / `_manual_calculate_sum()` compute the correct result client-side, avoiding the Flux crash ([influxdata/influxdb#21649](https://github.com/influxdata/influxdb/issues/21649)).
- **Grouped queries on InfluxDB 1.x**: Uses Flux `window()+reduce()+map()` server-side to compute per-window means without calling `aggregateWindow(fn: mean)`, keeping server-side processing (less data to the client) while avoiding the crash.
- **Callers simplified**: `output_sec_on`, `average_past_seconds`, `average_start_end_seconds`, and `sum_past_seconds` no longer contain version-specific workaround logic — they all consume the single aggregated value that `query_flux`/`query_string` now always returns.
- **Dead code removed**: `_manual_aggregate_mean()` function and its unreachable call site removed. All `TODO: Change median to mean when issue is fixed` comments removed.
- **Logging improved**: `logger.error` for the SUM workaround demoted to `logger.debug`.
- **Trailing whitespace fixed** in `influxdb_get_first_point()`.

## Testing

- 14 unit tests added in `mycodo/tests/software_tests/test_influxdb/test_manual_aggregation.py` covering `_manual_calculate_mean` and `_manual_calculate_sum` (empty input, None-skipping, single point, multiple points, correct scalar output — no live InfluxDB required).
- All 14 tests pass.

<!-- START COPILOT CODING AGENT TIPS -->
---

📱 Kick off Copilot coding agent tasks wherever you are with [GitHub Mobile](https://gh.io/cca-mobile-docs), available on iOS and Android.