### PR TITLE
move toasts underneath nav bar

### DIFF
--- a/mycodo/mycodo_flask/static/css/custom.css
+++ b/mycodo/mycodo_flask/static/css/custom.css
@@ -171,3 +171,7 @@
   max-width: 60%;
   max-height: 60%;
 }
+
+#toast-container {
+    top: 60px;
+}


### PR DESCRIPTION
I kept getting frustrated that I have to dismiss all the toasts before I can click "Data" and "Setup" in the top nav since they cover it up.

<img width="542" height="308" alt="Screenshot 2026-06-27 at 2 21 02 PM" src="https://github.com/user-attachments/assets/519302aa-4eeb-4ca7-851d-25c5381e0ef8" />

So this shifts the toast container down by 60px so that they are under the top nav

<img width="496" height="289" alt="Screenshot 2026-06-27 at 2 20 55 PM" src="https://github.com/user-attachments/assets/48a965ab-894b-4c01-a7aa-ab74242c034e" />
