### PR TITLE
Fix Atlas FTDI sensors

### DIFF
--- a/mycodo/inputs/atlas_co2.py
+++ b/mycodo/inputs/atlas_co2.py
@@ -38,7 +38,7 @@ INPUT_INFORMATION = {
     'options_disabled': ['interface'],
 
     'dependencies_module': [
-        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.20.0')
+        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.24.0')
     ],
 
     'interfaces': ['I2C', 'UART', 'FTDI'],

--- a/mycodo/inputs/atlas_do.py
+++ b/mycodo/inputs/atlas_do.py
@@ -46,7 +46,7 @@ INPUT_INFORMATION = {
     'options_disabled': ['interface'],
 
     'dependencies_module': [
-        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.20.0')
+        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.24.0')
     ],
 
     'interfaces': ['I2C', 'UART', 'FTDI'],

--- a/mycodo/inputs/atlas_ec.py
+++ b/mycodo/inputs/atlas_ec.py
@@ -59,7 +59,7 @@ INPUT_INFORMATION = {
     'options_disabled': ['interface'],
 
     'dependencies_module': [
-        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.20.0')
+        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.24.0')
     ],
 
     'interfaces': ['I2C', 'UART', 'FTDI'],

--- a/mycodo/inputs/atlas_flow.py
+++ b/mycodo/inputs/atlas_flow.py
@@ -113,7 +113,7 @@ INPUT_INFORMATION = {
     'options_disabled': ['interface'],
 
     'dependencies_module': [
-        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.20.0')
+        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.24.0')
     ],
 
     'interfaces': ['I2C', 'UART', 'FTDI'],

--- a/mycodo/inputs/atlas_humidity.py
+++ b/mycodo/inputs/atlas_humidity.py
@@ -46,7 +46,7 @@ INPUT_INFORMATION = {
     'options_disabled': ['interface'],
 
     'dependencies_module': [
-        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.20.0')
+        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.24.0')
     ],
 
     'interfaces': ['I2C', 'UART', 'FTDI'],

--- a/mycodo/inputs/atlas_o2.py
+++ b/mycodo/inputs/atlas_o2.py
@@ -47,7 +47,7 @@ INPUT_INFORMATION = {
     'options_disabled': ['interface'],
 
     'dependencies_module': [
-        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.20.0')
+        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.24.0')
     ],
 
     'interfaces': ['I2C', 'UART', 'FTDI'],

--- a/mycodo/inputs/atlas_orp.py
+++ b/mycodo/inputs/atlas_orp.py
@@ -45,7 +45,7 @@ INPUT_INFORMATION = {
     'options_disabled': ['interface'],
 
     'dependencies_module': [
-        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.20.0')
+        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.24.0')
     ],
 
     'interfaces': ['I2C', 'UART', 'FTDI'],

--- a/mycodo/inputs/atlas_ph.py
+++ b/mycodo/inputs/atlas_ph.py
@@ -49,7 +49,7 @@ INPUT_INFORMATION = {
     'options_disabled': ['interface'],
 
     'dependencies_module': [
-        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.20.0')
+        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.24.0')
     ],
 
     'interfaces': ['I2C', 'UART', 'FTDI'],

--- a/mycodo/inputs/atlas_pressure.py
+++ b/mycodo/inputs/atlas_pressure.py
@@ -37,7 +37,7 @@ INPUT_INFORMATION = {
     'options_disabled': ['interface'],
 
     'dependencies_module': [
-        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.20.0')
+        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.24.0')
     ],
 
     'interfaces': ['I2C', 'UART', 'FTDI'],

--- a/mycodo/inputs/atlas_pt1000.py
+++ b/mycodo/inputs/atlas_pt1000.py
@@ -37,7 +37,7 @@ INPUT_INFORMATION = {
     'options_disabled': ['interface'],
 
     'dependencies_module': [
-        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.20.0')
+        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.24.0')
     ],
 
     'interfaces': ['I2C', 'UART', 'FTDI'],

--- a/mycodo/inputs/atlas_rgb.py
+++ b/mycodo/inputs/atlas_rgb.py
@@ -84,7 +84,7 @@ INPUT_INFORMATION = {
     'options_disabled': ['interface'],
 
     'dependencies_module': [
-        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.20.0')
+        ('pip-pypi', 'pylibftdi', 'pylibftdi==0.24.0')
     ],
 
     'interfaces': ['I2C', 'UART', 'FTDI'],


### PR DESCRIPTION
I was getting errors trying to use the Atlas FTDI sensors.

`OSError: ftdi1: cannot open shared object file: No such file or directory`

Eventually I got it working by force installing the latest version of pylibftdi (0.24.0) with:

```
sudo /opt/Mycodo/env/bin/pip install --force-reinstall --no-cache-dir pylibftdi
```

However then when trying to add sensors in the web app, it thinks the dependencies aren't met and tries to install version 0.20.0.

This PR changes the dependencies to 0.24.0, and now the web app happily adds the sensors.

Apologies if this is the wrong way to do things, I am really not familiar with Python package management. 